### PR TITLE
feat(auth): add `grim login` / `grim logout`

### DIFF
--- a/.claude/artifacts/plan_login_logout.md
+++ b/.claude/artifacts/plan_login_logout.md
@@ -1,0 +1,101 @@
+# Plan — `grim login` / `grim logout`
+
+## Status
+
+- **Plan:** plan_login_logout
+- **Active phase:** 3 — Review-Fix Loop (converged, round 1)
+- **Step:** awaiting /finalize (ready for human review; not committed)
+- **Last update:** 2026-06-01 (review-fix applied; full `task verify` green)
+
+### Review-fix loop (round 1)
+
+Adversarial review (5 dimensions, per-finding verify) → 15 confirmed
+(3 block / 9 warn / 3 suggest). Fixed all actionable:
+
+- **block** helper stdout/stderr log leak (CWE-532) → `map_helper_err`
+  redacts `HelperFailure` into a payload-free `AuthError::HelperFailed`.
+- **block** blocking TTY/stdin reads on the async worker → `input_task`
+  (`spawn_blocking`).
+- **block** panic in `spawn_blocking` masked as `StoreIo` → `resume_unwind`.
+- **warn** logout TOCTOU (`path.exists()` before lock) → lock-free read;
+  lock taken only for the plaintext write.
+- **warn** `classify_auth` helper-variant coverage → explicit arms.
+- **warn** missing classify tests → added (auth + command paths).
+- **warn** stdin read error → classified `StoreIo` (IoError 74, not 1).
+- **warn** dead `auth.rs` re-exports → removed.
+- **warn** inaccurate `dup_credential` doc → corrected.
+- **warn** transient cleartext on heap → `Zeroizing` (stdin buf + `user:pass`).
+- **suggest** flock held across the 30s helper subprocess → helper path is
+  now lock-free (only the plaintext `auths` write takes the lock).
+
+Deferred (out of this diff's scope): double error log in `main.rs`
+(pre-existing); `print_json` DRY across 10+ pre-existing report types.
+
+## Goal
+
+Add `grim login` / `grim logout` so credentials can be **written** to the
+docker-compatible credential store. Grimoire already *reads* credentials
+(`oci::access::registry_client::auth_for` via `docker_credential`); only the
+write/erase half was missing.
+
+Adheres to Grimoire's simpler style — does **not** copy OCX's architecture
+(no lib/CLI workspace split, no `RegistryPing` verify seam in v1, no
+sticky-detect of the native helper). Reuses OCX's **patched external
+repository** (the `docker_credential` fork) and its login/logout shape.
+
+## Decisions (confirmed with maintainer)
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Fork vendoring | Git submodule `external/docker_credential` (ocx-sh fork) + `[patch.crates-io]`, pinned at `8e89cd0` (`feat/store-erase-list`) | Single source of truth; matches OCX. Only grimoire depends on `docker_credential` (oci-client 0.16 does not) → patch is self-contained |
+| Password input | `--password-stdin` **and** a hidden TTY prompt (`rpassword`) | Ergonomic like `docker login`, still no argv-visible secret |
+| Secret type | `secrecy::SecretString` | Redacts from `Debug`, zeroizes on drop |
+| Credential verify | None in v1 (store optimistically) | Matches `docker login` w/ helper; KISS. Function shape leaves room for a future `--verify` |
+
+## What landed
+
+- **Submodule** `external/docker_credential` + `[patch.crates-io]`; deps
+  `secrecy`, `rpassword`, `base64`.
+- **`src/auth/`** subsystem (named module files, no `mod.rs`):
+  `registry_url` (canonicalize), `credential` (secrecy), `auth_error`
+  (thiserror, `#[non_exhaustive]`), `store` (`CredentialStore` trait +
+  `DockerCredentialStore` over `~/.docker/config.json`, reuses
+  `ConfigFileLock` + `atomic_write`, enforces `0600`, drops OCX
+  sticky-detect), `prompt` (TTY username + hidden password), `login`
+  (login/logout ops).
+- **Commands** `src/command/login.rs`, `logout.rs`; report
+  `src/api/login_report.rs` (single-table plain, single-object JSON).
+- **Wiring**: `Command::{Login,Logout}` in `main.rs`/`app.rs`;
+  `Error::Auth(#[from] AuthError)` + `classify_auth` in `error.rs`;
+  `CommandError::{NoLoginRegistry, LoginInput}`; shared
+  `command::resolve_login_registry` / `login_usage`.
+- **Read/write key parity**: `registry_client::auth_for` now canonicalizes
+  its lookup key (fixes the `docker.io` alias round-trip); fork's new
+  `NotFound` helper-miss variant folded into the anonymous group.
+- **Docs**: `DOCKER_CONFIG` in CLAUDE.md env table; login/logout in the
+  command catalog.
+
+## Exit-code contract
+
+| Situation | Code |
+|---|---|
+| Success | 0 |
+| Missing/empty credential input (non-interactive) | 64 usage |
+| Malformed on-disk config | 65 data |
+| Store I/O failure | 74 io (77 if `EPERM`) |
+| No helper + no `--allow-insecure-store`; no config location; no registry | 78 config |
+| Helper auth failure / login rejected | 80 auth |
+
+## Verification
+
+- `cargo test`: 455 unit tests pass (incl. new auth/store/command tests).
+- `test/tests/test_login.py`: 12 acceptance tests pass (plaintext round-trip
+  + `0600`, refusal w/o opt-in, usage errors, JSON, logout no-op, mock
+  native-helper store/erase).
+- Full `task verify` green (fmt, clippy, license, build, 455 unit + 78
+  acceptance, shell, claude config tests, link check).
+
+## Out of scope (v1)
+
+Credential pre-verify (`--verify`/Ping), native-helper auto-detect, OAuth /
+browser flows, `--insecure` HTTP toggle for the (absent) verify path.

--- a/.claude/rules/subsystem-cli-commands.md
+++ b/.claude/rules/subsystem-cli-commands.md
@@ -24,9 +24,17 @@ column formats.
 | `grim remove <kind> <name>` | Undeclare an artifact (config + lock only; files left on disk) |
 | `grim uninstall <kind> <name>` | Full inverse of install: delete files, drop the install record, undeclare (config + lock). Shared seam reused by the TUI delete action |
 | `grim publish <path> <ref>` | Push an artifact to a registry |
+| `grim login [<registry>]` | Authenticate to a registry; store the credential via the docker-compatible credential store (helper or, with `--allow-insecure-store`, plaintext) |
+| `grim logout [<registry>]` | Remove a stored registry credential (idempotent — exits 0 when nothing is stored) |
 | `grim version` | Print the compiled version |
 
 Global flags (illustrative): `--offline`, `--remote`, `--format json`.
+
+`login`/`logout` resolve the registry from the positional argument, else
+`--registry` / the `default_registry` option / `GRIM_DEFAULT_REGISTRY`.
+They read and write the docker config at `$DOCKER_CONFIG/config.json`
+(default `~/.docker/config.json`) — the same file the credential read path
+consults — so credentials round-trip with `docker login`.
 
 ## Conventions (apply as commands land)
 

--- a/.github/workflows/verify-basic.yml
+++ b/.github/workflows/verify-basic.yml
@@ -34,6 +34,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # `external/docker_credential` is the [patch.crates-io] source; the
+          # build fails without it.
+          submodules: recursive
       - name: Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1.16.0
         with:

--- a/.github/workflows/verify-deep.yml
+++ b/.github/workflows/verify-deep.yml
@@ -23,6 +23,8 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          # `external/docker_credential` is the [patch.crates-io] source.
+          submodules: recursive
       - name: Build
         uses: ./.github/actions/build-rust
         with:
@@ -56,6 +58,8 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          # `external/docker_credential` is the [patch.crates-io] source.
+          submodules: recursive
       - name: Install Rust target
         run: rustup target add ${{ matrix.job.target }}
       - name: Build

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "external/docker_credential"]
+	path = external/docker_credential
+	url = https://github.com/ocx-sh/docker_credential.git
+	branch = feat/store-erase-list

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,7 @@ files:
 | `GRIM_DEFAULT_REGISTRY` | Default registry for short identifiers | (unset) |
 | `GRIM_OFFLINE` | Disable all network access | false |
 | `GRIM_REMOTE` | Route mutable lookups to the remote registry | false |
+| `DOCKER_CONFIG` | Directory holding the docker-compatible `config.json` read/written by `grim login`/`logout` (and the credential read path) | `~/.docker` |
 
 (Provisional — env surface grows as the implementation lands.)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -506,12 +506,11 @@ dependencies = [
 [[package]]
 name = "docker_credential"
 version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4564c274ebf369f501de192b02a0b81a5c4bda375abfe526aa70fc702fa6fa0"
 dependencies = [
  "base64",
  "serde",
  "serde_json",
+ "which",
 ]
 
 [[package]]
@@ -738,6 +737,7 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "base64",
  "chrono",
  "clap",
  "clap_complete",
@@ -749,6 +749,8 @@ dependencies = [
  "oci-client",
  "ratatui",
  "reqwest",
+ "rpassword",
+ "secrecy",
  "semver",
  "serde",
  "serde_json",
@@ -1742,6 +1744,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rpassword"
+version = "7.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2da316a15f47e3d053de9cb2c439650bd8fa4aaeb9365f2e5f27f492ff73c196"
+dependencies = [
+ "libc",
+ "rtoolbox",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50a0e551c1e27e1731aba276dbeaeac73f53c7cd34d1bda485d02bd1e0f36844"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1892,6 +1915,15 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "secrecy"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
+dependencies = [
+ "zeroize",
+]
 
 [[package]]
 name = "security-framework"
@@ -2787,6 +2819,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "which"
+version = "8.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81995fafaaaf6ae47a7d0cc83c67caf92aeb7e5331650ae6ff856f7c0c60c459"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,12 +43,24 @@ reqwest = { version = "0.13", default-features = false, features = ["rustls", "j
 tar = "0.4"
 ratatui = "0.29"
 crossterm = "0.28"
+base64 = "0.22"
+secrecy = "0.10"
+rpassword = "7"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
 [dev-dependencies]
 tempfile = "3"
+
+# `grim login` writes credentials through a docker-compatible store. The
+# upstream `docker_credential` crate only *reads*; the maintained fork adds
+# `store_credential` / `erase_credential` / `detect_default_helper` (the
+# write/erase path login/logout need). Pulled in via the
+# `external/docker_credential` submodule. Only Grimoire depends on this
+# crate (oci-client 0.16 does not), so the patch is self-contained.
+[patch.crates-io]
+docker_credential = { path = "external/docker_credential" }
 
 # The profile that 'dist' will build with
 [profile.dist]

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -7,4 +7,5 @@
 - [Concepts](./concepts.md)
 - [Command Reference](./commands.md)
 - [Configuration](./configuration.md)
+- [Authentication](./authentication.md)
 - [Publishing Skills and Rules](./publishing.md)

--- a/docs/src/authentication.md
+++ b/docs/src/authentication.md
@@ -1,0 +1,124 @@
+# Authentication
+
+Most public skills and rules pull anonymously, but a private registry wants
+to know who you are before it hands anything over. Grimoire does not invent
+its own login system for that — it reads and writes the same credential
+store [Docker][docker-login] and [oras][oras-login] already use, so a single
+`docker login` (or `grim login`) covers every tool on the machine.
+
+This page covers how Grimoire finds credentials when it talks to a registry,
+how [`grim login`](#login) and [`grim logout`](#logout) manage them, and
+where they are stored on disk.
+
+## How credentials are resolved {#resolving}
+
+Every registry request starts the same way: Grimoire looks up a credential
+for the target registry and falls back to anonymous access when it finds
+none. A missing credential is never an error — public artifacts keep
+working with no setup.
+
+The lookup reads `~/.docker/config.json` (or `$DOCKER_CONFIG/config.json`),
+the [Docker config file][docker-login]. If a [credential
+helper][docker-cred-helpers] is configured for the registry, Grimoire asks
+the helper; otherwise it reads the base64 entry under `auths`. The registry
+key is normalized first — the scheme and any `/v2/` API suffix are stripped,
+and `docker.io` is mapped to its canonical `https://index.docker.io/v1/`
+form — so a credential stored by `docker login` resolves the same way under
+`grim`.
+
+Credentials can also come from the environment for `GRIM_INSECURE_REGISTRIES`
+and other CI setups; see [Configuration](./configuration.md#environment-variables).
+
+## grim login {#login}
+
+`grim login [registry]` authenticates to a registry and stores the
+credential so later pulls and pushes reuse it. With no positional argument
+it resolves the registry the same way every command does — `--registry`,
+then the `default_registry` option, then `GRIM_DEFAULT_REGISTRY`.
+
+The username comes from `--username`/`-u`, or an interactive prompt when
+omitted on a terminal. The password is read from a hidden terminal prompt,
+or from standard input with `--password-stdin`. There is intentionally **no**
+`--password <value>` flag: a secret on the command line leaks through the
+process list and shell history.
+
+```sh
+# Interactive: prompts for the password without echoing it.
+grim login ghcr.io -u alice
+
+# Non-interactive (CI): read the token from stdin.
+echo "$GITHUB_TOKEN" | grim login ghcr.io -u alice --password-stdin
+```
+
+Where the credential lands depends on what is configured — see [Where
+credentials are stored](#store). When no credential helper is configured,
+Grimoire **refuses** to write a plaintext credential unless you opt in with
+`--allow-insecure-store`, which stores a base64 entry (not encryption) in
+`config.json`. The file is created with owner-only (`0600`) permissions.
+
+Grimoire stores the credential without first contacting the registry, which
+matches `docker login` with a credential helper. A wrong password therefore
+surfaces on the next pull or push, not at login time.
+
+## grim logout {#logout}
+
+`grim logout [registry]` removes a stored credential. It resolves the
+registry exactly like [`grim login`](#login).
+
+Logout is idempotent: removing a credential that was never stored exits `0`,
+matching [`docker logout`][docker-login] and [`oras logout`][oras-login] so a
+CI cleanup step never fails on a fresh runner.
+
+```sh
+grim logout ghcr.io
+```
+
+## Where credentials are stored {#store}
+
+Grimoire writes to the Docker-compatible config at
+`$DOCKER_CONFIG/config.json`, defaulting to `~/.docker/config.json`. Set
+`DOCKER_CONFIG` to point both Grimoire and Docker at an isolated directory —
+useful for tests and per-job CI credentials.
+
+The destination follows the same precedence [Docker][docker-login] uses,
+highest first:
+
+| Tier | Config key | Storage |
+|------|-----------|---------|
+| Per-registry helper | `credHelpers[registry]` | The named OS keychain helper. |
+| Default helper | `credsStore` | The named OS keychain helper. |
+| Plaintext fallback | `auths[registry]` | base64-encoded, gated by `--allow-insecure-store`. |
+
+A credential helper is a small program named `docker-credential-<name>` on
+your `PATH` that stores secrets in the OS keychain — for example
+`osxkeychain`, `wincred`, or `secretservice`/`pass` on Linux. The
+[docker-credential-helpers][docker-cred-helpers] project ships the common
+ones. When a helper is configured, the secret never touches `config.json`;
+only the helper name does.
+
+Unlike `docker login`, Grimoire does **not** auto-detect and silently enable
+a platform helper on first use. It writes only what is already configured,
+or the explicit plaintext fallback — so a shared machine never gains a
+sticky `credsStore` entry behind your back.
+
+## Credentials in CI {#ci}
+
+A headless runner usually has no terminal and no keychain. Pipe the token in
+and opt into the plaintext store scoped to a per-job `DOCKER_CONFIG`:
+
+```sh
+export DOCKER_CONFIG="$RUNNER_TEMP/docker"
+echo "$REGISTRY_TOKEN" | grim login "$REGISTRY" -u "$REGISTRY_USER" \
+  --password-stdin --allow-insecure-store
+grim release ./code-review "$REGISTRY/acme/code-review:1.2.3"
+grim logout "$REGISTRY"
+```
+
+Because Grimoire shares the Docker config, a prior [`docker login`][docker-login]
+step in the same job is enough on its own — `grim` reuses whatever Docker
+stored.
+
+<!-- external -->
+[docker-login]: https://docs.docker.com/reference/cli/docker/login/
+[docker-cred-helpers]: https://github.com/docker/docker-credential-helpers
+[oras-login]: https://oras.land/docs/commands/oras_login

--- a/docs/src/commands.md
+++ b/docs/src/commands.md
@@ -37,6 +37,8 @@ These apply to every subcommand:
 | [`grim tui`](#tui) | Browse the catalog interactively. |
 | [`grim build`](#build) | Validate and pack a local artifact. |
 | [`grim release`](#release) | Validate, pack, and push an artifact. |
+| [`grim login`](#login) | Authenticate to a registry and store the credential. |
+| [`grim logout`](#logout) | Remove a stored registry credential. |
 
 ## grim init {#init}
 
@@ -147,4 +149,30 @@ moves an existing exact-version tag that points at a different digest. See
 
 ```sh
 grim release ./code-review ghcr.io/acme/code-review:1.2.3 --dry-run
+```
+
+## grim login {#login}
+
+`grim login [registry]` authenticates to a registry and stores the credential
+in the Docker-compatible credential store, so later pulls and pushes reuse it.
+Pass the username with `-u`/`--username` (prompted on a terminal when omitted)
+and the password via `--password-stdin` or a hidden terminal prompt — there is
+no `--password <value>` flag, by design. `--allow-insecure-store` permits a
+base64 plaintext entry when no credential helper is configured. With no
+positional `registry`, it resolves `--registry`, then `default_registry`, then
+`GRIM_DEFAULT_REGISTRY`. See [Authentication](./authentication.md) for storage
+details.
+
+```sh
+echo "$TOKEN" | grim login ghcr.io -u alice --password-stdin
+```
+
+## grim logout {#logout}
+
+`grim logout [registry]` removes a stored credential. It is idempotent —
+logging out when nothing is stored exits `0` — and resolves the registry the
+same way [`grim login`](#login) does.
+
+```sh
+grim logout ghcr.io
 ```

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -63,6 +63,7 @@ applies.
 | `GRIM_OFFLINE` | Disable all network access (same as `--offline`). | `false` |
 | `GRIM_REMOTE` | Route mutable lookups to the live registry (same as `--remote`). | `false` |
 | `GRIM_INSECURE_REGISTRIES` | Comma-separated registries reachable over plain HTTP — for local or in-cluster registries without TLS. | unset |
+| `DOCKER_CONFIG` | Directory holding the Docker-compatible `config.json` that [`grim login`](./authentication.md) reads and writes. | `~/.docker` |
 
 A command-line flag always wins. Where a setting also has a config option, the
 config option wins over the environment variable: the registry resolves as

--- a/src/api.rs
+++ b/src/api.rs
@@ -15,6 +15,7 @@ pub mod build_report;
 pub mod init_report;
 pub mod install_report;
 pub mod lock_report;
+pub mod login_report;
 pub mod release_report;
 pub mod remove_report;
 pub mod search_report;
@@ -34,6 +35,8 @@ pub use init_report::InitReport;
 pub use install_report::{InstallEntry, InstallReport};
 #[allow(unused_imports)]
 pub use lock_report::{LockEntry, LockReport};
+#[allow(unused_imports)]
+pub use login_report::{LoginReport, LogoutReport};
 #[allow(unused_imports)]
 pub use release_report::ReleaseReport;
 #[allow(unused_imports)]

--- a/src/api/login_report.rs
+++ b/src/api/login_report.rs
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The Grimoire Authors
+
+//! `grim login` / `grim logout` output.
+//!
+//! Plain format: a single confirmation table — `Registry | Username` for
+//! login, `Registry` for logout.
+//!
+//! JSON format: a single object (`{"registry","username"}` /
+//! `{"registry"}`), not an array — there is exactly one subject.
+
+use std::io::{self, Write};
+
+use serde::Serialize;
+
+use crate::cli::printer::{Printable, print_table};
+
+/// The result of a successful `grim login`.
+#[derive(Debug, Serialize)]
+pub struct LoginReport {
+    /// The registry the credential was stored for (canonical form).
+    pub registry: String,
+    /// The account name that was authenticated.
+    pub username: String,
+}
+
+impl LoginReport {
+    /// Build from the resolved registry and username.
+    pub fn new(registry: impl Into<String>, username: impl Into<String>) -> Self {
+        Self {
+            registry: registry.into(),
+            username: username.into(),
+        }
+    }
+}
+
+impl Printable for LoginReport {
+    fn print_plain(&self, w: &mut impl Write) -> io::Result<()> {
+        print_table(
+            w,
+            &["Registry", "Username"],
+            &[vec![self.registry.clone(), self.username.clone()]],
+        )
+    }
+
+    fn print_json(&self, w: &mut impl Write) -> io::Result<()> {
+        let json = serde_json::to_string_pretty(self).map_err(io::Error::other)?;
+        writeln!(w, "{json}")
+    }
+}
+
+/// The result of a successful `grim logout`.
+#[derive(Debug, Serialize)]
+pub struct LogoutReport {
+    /// The registry the credential was removed for (canonical form).
+    pub registry: String,
+}
+
+impl LogoutReport {
+    /// Build from the resolved registry.
+    pub fn new(registry: impl Into<String>) -> Self {
+        Self {
+            registry: registry.into(),
+        }
+    }
+}
+
+impl Printable for LogoutReport {
+    fn print_plain(&self, w: &mut impl Write) -> io::Result<()> {
+        print_table(w, &["Registry"], &[vec![self.registry.clone()]])
+    }
+
+    fn print_json(&self, w: &mut impl Write) -> io::Result<()> {
+        let json = serde_json::to_string_pretty(self).map_err(io::Error::other)?;
+        writeln!(w, "{json}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn login_plain_is_single_table_with_header() {
+        let r = LoginReport::new("ghcr.io", "alice");
+        let mut buf = Vec::new();
+        r.print_plain(&mut buf).unwrap();
+        let out = String::from_utf8(buf).unwrap();
+        let lines: Vec<&str> = out.lines().collect();
+        assert!(lines[0].starts_with("Registry"));
+        assert!(lines[0].contains("Username"));
+        assert!(lines[1].contains("ghcr.io"));
+        assert!(lines[1].contains("alice"));
+    }
+
+    #[test]
+    fn login_json_is_single_object() {
+        let r = LoginReport::new("ghcr.io", "alice");
+        let mut buf = Vec::new();
+        r.print_json(&mut buf).unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&buf).unwrap();
+        assert!(v.is_object());
+        assert_eq!(v["registry"], "ghcr.io");
+        assert_eq!(v["username"], "alice");
+    }
+
+    #[test]
+    fn logout_json_carries_only_registry() {
+        let r = LogoutReport::new("ghcr.io");
+        let mut buf = Vec::new();
+        r.print_json(&mut buf).unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&buf).unwrap();
+        assert_eq!(v["registry"], "ghcr.io");
+        assert!(v.get("username").is_none());
+    }
+}

--- a/src/app.rs
+++ b/src/app.rs
@@ -95,6 +95,16 @@ pub async fn run(cli: Cli) -> anyhow::Result<ExitCode> {
             render(&r, format)?;
             c
         }
+        Command::Login(args) => {
+            let (r, c) = crate::command::login::run(&ctx, &args).await?;
+            render(&r, format)?;
+            c
+        }
+        Command::Logout(args) => {
+            let (r, c) = crate::command::logout::run(&ctx, &args).await?;
+            render(&r, format)?;
+            c
+        }
         // `tui` diverges into a full-screen session: it owns the terminal
         // and emits no structured report (exempt from `Printable`).
         Command::Tui(args) => crate::command::tui::run(&ctx, &args).await?,

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The Grimoire Authors
+
+//! Authentication subsystem: the credential model, a docker-compatible
+//! credential store, and the login/logout operations.
+//!
+//! `grim` already *reads* registry credentials in
+//! [`crate::oci::access::registry_client`] (docker config + helpers, via
+//! the `docker_credential` crate). This module adds the *write* side that
+//! `grim login` / `grim logout` need: a [`CredentialStore`] over
+//! `~/.docker/config.json`, backed by the patched `docker_credential`
+//! fork's helper store/erase primitives. Read and write share one
+//! registry-key normalization ([`canonicalize_registry`]) so a credential
+//! written by `grim login` is found by a later resolve.
+
+pub mod auth_error;
+pub mod credential;
+pub mod login;
+pub mod prompt;
+pub mod registry_url;
+pub mod store;
+
+// The only re-export with a cross-module consumer: the credential read path
+// (`oci::access::registry_client`) and the store share one registry-key
+// normalization. Other subsystem types are reached via their full module
+// path (e.g. `auth::store::DockerCredentialStore`), matching the rest of the
+// crate, so they are not re-exported here.
+pub use registry_url::canonicalize_registry;

--- a/src/auth/auth_error.rs
+++ b/src/auth/auth_error.rs
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The Grimoire Authors
+
+//! Authentication-tier error type.
+//!
+//! Composes into the top-level [`crate::error::Error`] via `#[from]`;
+//! [`crate::error::classify_error`] maps each variant to an [`ExitCode`].
+//! Messages follow the Rust API Guidelines (lowercase, no trailing
+//! punctuation) so they read cleanly in an `anyhow` `{:#}` chain.
+//!
+//! [`ExitCode`]: crate::cli::exit_code::ExitCode
+
+use std::path::PathBuf;
+
+/// An error raised while reading or writing registry credentials.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum AuthError {
+    /// Reading or writing `~/.docker/config.json` failed.
+    #[error("failed to access credential store at {path}")]
+    StoreIo {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// The on-disk `config.json` was not valid JSON.
+    #[error("credential store at {path} is not valid JSON")]
+    MalformedConfig {
+        path: PathBuf,
+        #[source]
+        source: serde_json::Error,
+    },
+
+    /// A credential-helper subprocess failed.
+    #[error("credential helper failed")]
+    Helper(#[source] docker_credential::CredentialRetrievalError),
+
+    /// A credential helper exited non-zero. Distinct from [`Self::Helper`]
+    /// because the underlying `HelperFailure` carries the helper's raw
+    /// stdout/stderr (which can contain credentials) in its `Display`; this
+    /// variant drops that payload so it never reaches a log line (CWE-532).
+    #[error("credential helper '{helper}' exited non-zero")]
+    HelperFailed { helper: String },
+
+    /// No credential store is available: no helper is configured and the
+    /// user did not opt into the plaintext fallback.
+    #[error("no credential store available; configure a docker credential helper or pass --allow-insecure-store")]
+    NoCredentialStore,
+
+    /// The docker config location could not be resolved (no `$HOME` and no
+    /// `$DOCKER_CONFIG`).
+    #[error("cannot locate docker config; set $DOCKER_CONFIG or $HOME")]
+    NoConfigLocation,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn messages_are_lowercase_without_trailing_period() {
+        for msg in [
+            AuthError::NoCredentialStore.to_string(),
+            AuthError::NoConfigLocation.to_string(),
+        ] {
+            let first = msg.chars().next().unwrap();
+            assert!(first.is_lowercase(), "message must start lowercase: {msg:?}");
+            assert!(!msg.ends_with('.'), "message must not end with a period: {msg:?}");
+        }
+    }
+}

--- a/src/auth/credential.rs
+++ b/src/auth/credential.rs
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The Grimoire Authors
+
+//! The in-memory credential a `grim login` collects and the store
+//! persists.
+//!
+//! Secret fields are wrapped in [`SecretString`] so they are redacted from
+//! `Debug` output and zeroized on drop — a `grim` panic or a stray
+//! `tracing` line can never leak a token. The struct mirrors the docker
+//! credential-helper wire shape (`{username, secret, identitytoken}`):
+//!
+//! - `username` + `password` → HTTP Basic
+//! - `identity_token` alone → OAuth2 refresh token (wire `identitytoken`)
+
+use secrecy::{ExposeSecret as _, SecretString};
+
+/// A registry credential, secrets redacted in `Debug`.
+#[derive(Debug, Default)]
+pub struct Credential {
+    /// Account name. Empty for an identity-token-only credential.
+    pub username: String,
+    /// Basic-auth secret. Empty when an identity token is used instead.
+    pub password: SecretString,
+    /// OAuth2 identity (refresh) token. Empty for basic auth.
+    pub identity_token: SecretString,
+}
+
+impl Credential {
+    /// Construct a basic-auth credential (the common `grim login` case).
+    pub fn basic(username: impl Into<String>, password: SecretString) -> Self {
+        Self {
+            username: username.into(),
+            password,
+            identity_token: SecretString::default(),
+        }
+    }
+
+    /// Construct an identity-token credential (OAuth2 refresh).
+    pub fn identity_token(token: SecretString) -> Self {
+        Self {
+            username: String::new(),
+            password: SecretString::default(),
+            identity_token: token,
+        }
+    }
+
+    /// True when every field is empty.
+    pub fn is_empty(&self) -> bool {
+        self.username.is_empty()
+            && self.password.expose_secret().is_empty()
+            && self.identity_token.expose_secret().is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn basic_populates_username_and_password() {
+        let c = Credential::basic("alice", SecretString::from("hunter2"));
+        assert_eq!(c.username, "alice");
+        assert_eq!(c.password.expose_secret(), "hunter2");
+        assert!(c.identity_token.expose_secret().is_empty());
+        assert!(!c.is_empty());
+    }
+
+    #[test]
+    fn identity_token_leaves_basic_fields_empty() {
+        let c = Credential::identity_token(SecretString::from("tok"));
+        assert!(c.username.is_empty());
+        assert!(c.password.expose_secret().is_empty());
+        assert_eq!(c.identity_token.expose_secret(), "tok");
+    }
+
+    #[test]
+    fn default_is_empty() {
+        assert!(Credential::default().is_empty());
+    }
+
+    #[test]
+    fn debug_redacts_secret_fields() {
+        let c = Credential::basic("alice", SecretString::from("DO_NOT_LEAK"));
+        let dbg = format!("{c:?}");
+        assert!(!dbg.contains("DO_NOT_LEAK"), "Debug leaked the secret: {dbg}");
+    }
+}

--- a/src/auth/login.rs
+++ b/src/auth/login.rs
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The Grimoire Authors
+
+//! Login / logout operations — the seam between the CLI commands and the
+//! credential store.
+//!
+//! Kept as free functions (not methods on the store trait) so the trait
+//! stays the three minimal protocol verbs. The registry argument is
+//! canonicalized by [`CredentialStore`] implementations themselves, so
+//! these wrappers pass it straight through.
+//!
+//! v1 does not verify the credential against the registry before storing
+//! it (matching `docker login` with a credential helper, which also stores
+//! optimistically). The function shape leaves room for a future
+//! `--verify` pre-flight without changing call sites.
+
+use crate::auth::auth_error::AuthError;
+use crate::auth::credential::Credential;
+use crate::auth::store::CredentialStore;
+
+/// Persist `cred` for `registry` via `store`.
+///
+/// # Errors
+///
+/// Any [`AuthError`] the store raises while writing.
+pub async fn login(registry: &str, cred: &Credential, store: &dyn CredentialStore) -> Result<(), AuthError> {
+    store.put(registry, cred).await
+}
+
+/// Remove any stored credential for `registry` via `store`. Idempotent:
+/// `Ok(())` whether or not one was present.
+///
+/// # Errors
+///
+/// Any [`AuthError`] the store raises while erasing.
+pub async fn logout(registry: &str, store: &dyn CredentialStore) -> Result<(), AuthError> {
+    store.delete(registry).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use secrecy::SecretString;
+    use std::sync::Mutex;
+
+    #[derive(Default)]
+    struct MockStore {
+        puts: Mutex<Vec<String>>,
+        deletes: Mutex<Vec<String>>,
+    }
+
+    #[async_trait::async_trait]
+    impl CredentialStore for MockStore {
+        async fn get(&self, _registry: &str) -> Result<Option<Credential>, AuthError> {
+            Ok(None)
+        }
+        async fn put(&self, registry: &str, _cred: &Credential) -> Result<(), AuthError> {
+            self.puts.lock().unwrap().push(registry.to_string());
+            Ok(())
+        }
+        async fn delete(&self, registry: &str) -> Result<(), AuthError> {
+            self.deletes.lock().unwrap().push(registry.to_string());
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn login_invokes_store_put() {
+        let store = MockStore::default();
+        let cred = Credential::basic("u", SecretString::from("p"));
+        login("ghcr.io", &cred, &store).await.expect("login");
+        assert_eq!(store.puts.lock().unwrap().as_slice(), &["ghcr.io".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn logout_invokes_store_delete() {
+        let store = MockStore::default();
+        logout("ghcr.io", &store).await.expect("logout");
+        assert_eq!(store.deletes.lock().unwrap().as_slice(), &["ghcr.io".to_string()]);
+    }
+}

--- a/src/auth/prompt.rs
+++ b/src/auth/prompt.rs
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The Grimoire Authors
+
+//! Interactive terminal prompts for `grim login`.
+//!
+//! Prompts are written to **stderr** so stdout stays a clean machine
+//! interface (a `--format json` `LoginReport` is the only thing on stdout).
+//! Both prompts refuse a non-terminal stdin with [`io::ErrorKind::Unsupported`]
+//! so the command can map that to an actionable usage error instead of a
+//! confusing read failure.
+
+use std::io::{self, IsTerminal as _, Write as _};
+
+use secrecy::SecretString;
+
+/// Prompt for and read a username line from the terminal.
+///
+/// # Errors
+///
+/// [`io::ErrorKind::Unsupported`] when stdin is not a TTY; any other I/O
+/// error from writing the prompt or reading the line.
+pub fn prompt_username() -> io::Result<String> {
+    if !io::stdin().is_terminal() {
+        return Err(io::Error::new(io::ErrorKind::Unsupported, "stdin is not a terminal"));
+    }
+    let mut stderr = io::stderr();
+    write!(stderr, "Username: ")?;
+    stderr.flush()?;
+    let mut line = String::new();
+    io::stdin().read_line(&mut line)?;
+    Ok(line.trim_end_matches(['\r', '\n']).to_string())
+}
+
+/// Prompt for and read a password from the terminal without echoing it.
+///
+/// # Errors
+///
+/// [`io::ErrorKind::Unsupported`] when stdin is not a TTY; any other I/O
+/// error from writing the prompt or reading the hidden input.
+pub fn prompt_password() -> io::Result<SecretString> {
+    if !io::stdin().is_terminal() {
+        return Err(io::Error::new(io::ErrorKind::Unsupported, "stdin is not a terminal"));
+    }
+    let mut stderr = io::stderr();
+    write!(stderr, "Password: ")?;
+    stderr.flush()?;
+    // `read_password` reads hidden input from the terminal; the prompt was
+    // already emitted on stderr above so stdout stays clean.
+    Ok(SecretString::from(rpassword::read_password()?))
+}

--- a/src/auth/registry_url.rs
+++ b/src/auth/registry_url.rs
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The Grimoire Authors
+
+//! Registry URL canonicalization shared by the credential read path
+//! (`oci::access::registry_client`) and the write path (`auth::store`).
+//!
+//! Both paths MUST route through [`canonicalize_registry`] so a credential
+//! written under the key `ghcr.io` by `grim login https://ghcr.io/v1/` is
+//! found by a later read for `ghcr.io`. Single source of truth — prevents
+//! drift between the helper-lookup key and the stored key.
+
+/// Canonicalize a user-supplied registry argument into the key form used
+/// by `~/.docker/config.json` `auths` / `credHelpers` / `credsStore`
+/// lookups.
+///
+/// Algorithm (matches `docker/cli` `normalizeRegistry`):
+/// 1. Strip a leading `http://` or `https://` scheme.
+/// 2. Strip a trailing `/vN` or `/vN/` API-version suffix.
+/// 3. Strip a trailing `/`.
+/// 4. Special-case `docker.io` / `index.docker.io` →
+///    `https://index.docker.io/v1/` for round-trip with `docker login`.
+pub fn canonicalize_registry(input: &str) -> String {
+    let stripped = input
+        .strip_prefix("https://")
+        .or_else(|| input.strip_prefix("http://"))
+        .unwrap_or(input);
+
+    let trimmed = strip_trailing_api_version(stripped);
+    let trimmed = trimmed.trim_end_matches('/');
+
+    if trimmed == "docker.io" || trimmed == "index.docker.io" {
+        return "https://index.docker.io/v1/".to_string();
+    }
+
+    trimmed.to_string()
+}
+
+/// Strip a trailing `/vN` or `/vN/` segment where `N` is one or more
+/// digits. Returns the input unchanged when no such suffix is present.
+fn strip_trailing_api_version(s: &str) -> &str {
+    let bytes = s.as_bytes();
+    if bytes.is_empty() {
+        return s;
+    }
+    let mut cursor = bytes.len();
+    if bytes[cursor - 1] == b'/' {
+        cursor -= 1;
+    }
+    let digits_end = cursor;
+    while cursor > 0 && bytes[cursor - 1].is_ascii_digit() {
+        cursor -= 1;
+    }
+    if cursor == digits_end {
+        return s; // no digits — not a /vN suffix
+    }
+    if cursor == 0 || bytes[cursor - 1] != b'v' {
+        return s;
+    }
+    cursor -= 1; // consume 'v'
+    if cursor == 0 || bytes[cursor - 1] != b'/' {
+        return s;
+    }
+    &s[..cursor]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn canonicalize_registry_matches_docker_normalization() {
+        let cases = [
+            ("ghcr.io", "ghcr.io"),
+            ("https://ghcr.io", "ghcr.io"),
+            ("https://ghcr.io/", "ghcr.io"),
+            ("https://ghcr.io/v1/", "ghcr.io"),
+            ("https://ghcr.io/v2/", "ghcr.io"),
+            ("http://localhost:5000", "localhost:5000"),
+            ("docker.io", "https://index.docker.io/v1/"),
+            ("index.docker.io", "https://index.docker.io/v1/"),
+        ];
+        for (input, expected) in cases {
+            assert_eq!(
+                canonicalize_registry(input),
+                expected,
+                "canonicalize_registry({input:?}) should equal {expected:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn canonicalize_registry_preserves_non_version_paths() {
+        // A path segment that merely looks numeric but is not a `/vN` suffix
+        // must survive untouched.
+        assert_eq!(canonicalize_registry("example.com/v"), "example.com/v");
+        assert_eq!(canonicalize_registry("example.com/123"), "example.com/123");
+    }
+}

--- a/src/auth/store.rs
+++ b/src/auth/store.rs
@@ -1,0 +1,539 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The Grimoire Authors
+
+//! Docker-compatible credential store over `~/.docker/config.json`.
+//!
+//! `grim` already *reads* credentials through this file in
+//! `oci::access::registry_client`; this is the *write* half that
+//! `grim login` / `grim logout` need. Resolution order matches docker /
+//! oras:
+//! 1. `credHelpers[registry]` — per-registry helper (highest priority)
+//! 2. `credsStore` — global default helper
+//! 3. `auths[registry]` — plaintext base64 fallback (gated by
+//!    `allow_plaintext_put`, lowest priority)
+//!
+//! Helper store/erase go through the patched `docker_credential` fork.
+//! Plaintext writes reuse the crate-wide [`atomic_write`] primitive (then
+//! tighten the mode to `0600` — a credentials file must never inherit the
+//! `0644` cap `atomic_write` applies to ordinary state files). Concurrent
+//! `grim` writers serialize through [`ConfigFileLock`]; unknown JSON keys
+//! written by `docker` / `oras` round-trip untouched.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use async_trait::async_trait;
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD as BASE64;
+use secrecy::zeroize::Zeroizing;
+use secrecy::{ExposeSecret as _, SecretString};
+use serde::{Deserialize, Serialize};
+
+use crate::auth::auth_error::AuthError;
+use crate::auth::credential::Credential;
+use crate::auth::registry_url::canonicalize_registry;
+use crate::lock::file_lock::ConfigFileLock;
+use crate::lock::lock_error::LockErrorKind;
+use crate::store::atomic_write::atomic_write;
+
+/// Knobs controlling [`DockerCredentialStore`] behaviour.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct StoreOptions {
+    /// Allow `put` to fall through to a plaintext `auths[registry]` entry
+    /// when no credential helper is configured. Default `false` (the safe
+    /// default); `grim login --allow-insecure-store` opts in for headless
+    /// environments with no native keychain.
+    pub allow_plaintext_put: bool,
+}
+
+/// The three credential-store verbs (docker credential-helper protocol).
+#[async_trait]
+pub trait CredentialStore: Send + Sync {
+    /// Fetch the credential for `registry`. `Ok(None)` when none is stored.
+    async fn get(&self, registry: &str) -> Result<Option<Credential>, AuthError>;
+
+    /// Persist `cred` for `registry`.
+    async fn put(&self, registry: &str, cred: &Credential) -> Result<(), AuthError>;
+
+    /// Remove the credential for `registry`. `Ok(())` whether or not one
+    /// was present (idempotent, matching `docker logout`).
+    async fn delete(&self, registry: &str) -> Result<(), AuthError>;
+}
+
+/// A [`CredentialStore`] backed by `~/.docker/config.json` plus the
+/// configured credential helpers.
+#[derive(Debug, Clone)]
+pub struct DockerCredentialStore {
+    config_path: PathBuf,
+    allow_plaintext_put: bool,
+}
+
+impl DockerCredentialStore {
+    /// Construct a store pointed at the resolved docker config path
+    /// (`$DOCKER_CONFIG/config.json` or `~/.docker/config.json`).
+    ///
+    /// # Errors
+    ///
+    /// [`AuthError::NoConfigLocation`] when neither `$DOCKER_CONFIG` nor a
+    /// home directory can be determined.
+    pub fn new(opts: StoreOptions) -> Result<Self, AuthError> {
+        let config_path = crate::env::docker_config_path().ok_or(AuthError::NoConfigLocation)?;
+        Ok(Self {
+            config_path,
+            allow_plaintext_put: opts.allow_plaintext_put,
+        })
+    }
+
+    /// Construct a store pointed at an explicit path (tests, and callers
+    /// that resolve the path themselves).
+    pub fn with_path(config_path: PathBuf, opts: StoreOptions) -> Self {
+        Self {
+            config_path,
+            allow_plaintext_put: opts.allow_plaintext_put,
+        }
+    }
+
+    /// The on-disk path this store reads and mutates.
+    pub fn config_path(&self) -> &Path {
+        &self.config_path
+    }
+}
+
+#[async_trait]
+impl CredentialStore for DockerCredentialStore {
+    async fn get(&self, registry: &str) -> Result<Option<Credential>, AuthError> {
+        let canonical = canonicalize_registry(registry);
+        let path = self.config_path.clone();
+        run_blocking(self.config_path.clone(), move || get_blocking(&path, &canonical)).await
+    }
+
+    async fn put(&self, registry: &str, cred: &Credential) -> Result<(), AuthError> {
+        let canonical = canonicalize_registry(registry);
+        let path = self.config_path.clone();
+        let allow_plaintext = self.allow_plaintext_put;
+        let cred = dup_credential(cred);
+        run_blocking(self.config_path.clone(), move || {
+            put_blocking(&path, &canonical, &cred, allow_plaintext)
+        })
+        .await
+    }
+
+    async fn delete(&self, registry: &str) -> Result<(), AuthError> {
+        let canonical = canonicalize_registry(registry);
+        let path = self.config_path.clone();
+        run_blocking(self.config_path.clone(), move || delete_blocking(&path, &canonical)).await
+    }
+}
+
+// ── blocking core (runs inside spawn_blocking) ─────────────────────────
+
+/// Run a blocking store op on the blocking pool.
+///
+/// A panic inside the closure is re-raised on the caller thread
+/// (`resume_unwind`) rather than masked as an I/O error — masking a panic
+/// would hide a logic bug behind a benign-looking `StoreIo`. Only a genuine
+/// cancellation falls through to `StoreIo`.
+async fn run_blocking<T, F>(path: PathBuf, f: F) -> Result<T, AuthError>
+where
+    F: FnOnce() -> Result<T, AuthError> + Send + 'static,
+    T: Send + 'static,
+{
+    match tokio::task::spawn_blocking(f).await {
+        Ok(result) => result,
+        Err(join) if join.is_panic() => std::panic::resume_unwind(join.into_panic()),
+        Err(join) => Err(AuthError::StoreIo {
+            path,
+            source: std::io::Error::other(join),
+        }),
+    }
+}
+
+fn get_blocking(path: &Path, canonical: &str) -> Result<Option<Credential>, AuthError> {
+    let config = read_config(path)?;
+    match resolve_helper(&config, canonical) {
+        Some(helper) => match docker_credential::credential_from_helper(canonical, &helper) {
+            Ok(docker_credential::DockerCredential::UsernamePassword(user, pass)) => {
+                Ok(Some(Credential::basic(user, SecretString::from(pass))))
+            }
+            Ok(docker_credential::DockerCredential::IdentityToken(tok)) => {
+                Ok(Some(Credential::identity_token(SecretString::from(tok))))
+            }
+            Err(docker_credential::CredentialRetrievalError::NotFound) => Ok(None),
+            Err(err) => Err(map_helper_err(&helper, err)),
+        },
+        None => Ok(read_plaintext(&config, canonical)),
+    }
+}
+
+fn put_blocking(path: &Path, canonical: &str, cred: &Credential, allow_plaintext: bool) -> Result<(), AuthError> {
+    // Resolve the tier from a lock-free read: the helper path does not touch
+    // `config.json`, so it needs neither the file to exist nor the advisory
+    // lock (and must NOT hold the lock across the helper subprocess).
+    let config = read_config(path)?;
+
+    if let Some(helper) = resolve_helper(&config, canonical) {
+        return docker_credential::store_credential(canonical, &helper, &to_docker_credential(cred))
+            .map_err(|err| map_helper_err(&helper, err));
+    }
+    if !allow_plaintext {
+        return Err(AuthError::NoCredentialStore);
+    }
+
+    // Plaintext path: the only branch that writes `config.json`, so it is the
+    // only branch that takes the lock and re-reads under it.
+    ensure_config_file(path)?;
+    let _lock = acquire_lock(path)?;
+    let mut config = read_config(path)?;
+    let entry = config.auths.entry(canonical.to_string()).or_default();
+    if !cred.identity_token.expose_secret().is_empty() {
+        entry.identity_token = Some(cred.identity_token.expose_secret().to_string());
+        entry.auth = None;
+    } else {
+        // Zeroized so the cleartext `user:password` does not linger on the
+        // heap after the base64 encode (defense in depth alongside `secrecy`).
+        let user_pass = Zeroizing::new(format!("{}:{}", cred.username, cred.password.expose_secret()));
+        entry.auth = Some(BASE64.encode(user_pass.as_bytes()));
+        entry.identity_token = None;
+    }
+    write_config(path, &config)
+}
+
+fn delete_blocking(path: &Path, canonical: &str) -> Result<(), AuthError> {
+    // Lock-free read: a missing file resolves to the default (empty) config,
+    // so an absent store is a clean no-op without a `path.exists()` pre-check
+    // (which would race the lock acquisition).
+    let config = read_config(path)?;
+
+    // Helper erase needs no config.json lock — the helper owns its store, and
+    // `erase_credential` already maps the not-found sentinel to `Ok`.
+    if let Some(helper) = resolve_helper(&config, canonical) {
+        docker_credential::erase_credential(canonical, &helper).map_err(|err| map_helper_err(&helper, err))?;
+    }
+
+    // Only the plaintext removal mutates config.json, so only it takes the
+    // lock and re-reads under it.
+    if config.auths.contains_key(canonical) {
+        let _lock = acquire_lock(path)?;
+        let mut config = read_config(path)?;
+        if config.auths.remove(canonical).is_some() {
+            write_config(path, &config)?;
+        }
+    }
+    Ok(())
+}
+
+/// Convert a credential-helper error into an [`AuthError`], **redacting** the
+/// `HelperFailure` variant.
+///
+/// The upstream `HelperFailure` `Display` dumps the helper's raw `stdout` /
+/// `stderr`, which on a `get` can contain credential JSON. That text would
+/// otherwise reach the `tracing::error!("{err:#}")` chain in `main` (CWE-532).
+/// Every other variant's `Display` is credential-free and passes through.
+fn map_helper_err(helper: &str, err: docker_credential::CredentialRetrievalError) -> AuthError {
+    match err {
+        docker_credential::CredentialRetrievalError::HelperFailure { .. } => AuthError::HelperFailed {
+            helper: helper.to_string(),
+        },
+        other => AuthError::Helper(other),
+    }
+}
+
+// ── docker config.json schema (unknown keys preserved) ─────────────────
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct DockerConfig {
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    auths: BTreeMap<String, AuthEntry>,
+    #[serde(default, skip_serializing_if = "Option::is_none", rename = "credsStore")]
+    creds_store: Option<String>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty", rename = "credHelpers")]
+    cred_helpers: BTreeMap<String, String>,
+    /// Any key `docker` / `oras` / `podman` wrote that we do not model.
+    #[serde(flatten)]
+    other: serde_json::Map<String, serde_json::Value>,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct AuthEntry {
+    /// base64(`username:password`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    auth: Option<String>,
+    /// OAuth2 identity token (mutually exclusive with `auth` in practice).
+    #[serde(default, skip_serializing_if = "Option::is_none", rename = "identitytoken")]
+    identity_token: Option<String>,
+    #[serde(flatten)]
+    other: serde_json::Map<String, serde_json::Value>,
+}
+
+// ── helpers ────────────────────────────────────────────────────────────
+
+/// The helper configured for `canonical`: per-registry first, then global.
+fn resolve_helper(config: &DockerConfig, canonical: &str) -> Option<String> {
+    config
+        .cred_helpers
+        .get(canonical)
+        .cloned()
+        .or_else(|| config.creds_store.clone())
+}
+
+fn read_plaintext(config: &DockerConfig, canonical: &str) -> Option<Credential> {
+    let entry = config.auths.get(canonical)?;
+    if let Some(token) = &entry.identity_token {
+        return Some(Credential::identity_token(SecretString::from(token.clone())));
+    }
+    let decoded = BASE64.decode(entry.auth.as_ref()?.as_bytes()).ok()?;
+    let decoded = String::from_utf8(decoded).ok()?;
+    let (user, pass) = decoded.split_once(':')?;
+    Some(Credential::basic(
+        user.to_string(),
+        SecretString::from(pass.to_string()),
+    ))
+}
+
+fn to_docker_credential(cred: &Credential) -> docker_credential::DockerCredential {
+    if !cred.identity_token.expose_secret().is_empty() {
+        docker_credential::DockerCredential::IdentityToken(cred.identity_token.expose_secret().to_string())
+    } else {
+        docker_credential::DockerCredential::UsernamePassword(
+            cred.username.clone(),
+            cred.password.expose_secret().to_string(),
+        )
+    }
+}
+
+/// Reconstruct an owned [`Credential`] so it can move into the blocking
+/// closure (`SecretString` is intentionally not `Clone`). Each secret is
+/// briefly exposed to a heap `String` during the move — the exposure window
+/// is construction-only (immediately re-wrapped in `SecretString`), but it
+/// is not zero. `secrecy` zeroizes both the source and the rewrapped copy on
+/// drop.
+fn dup_credential(cred: &Credential) -> Credential {
+    Credential {
+        username: cred.username.clone(),
+        password: SecretString::from(cred.password.expose_secret().to_string()),
+        identity_token: SecretString::from(cred.identity_token.expose_secret().to_string()),
+    }
+}
+
+/// Read and parse the docker config. A missing or empty file is the
+/// default (empty) config; malformed JSON is an error.
+fn read_config(path: &Path) -> Result<DockerConfig, AuthError> {
+    let bytes = match std::fs::read(path) {
+        Ok(b) => b,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(DockerConfig::default()),
+        Err(source) => {
+            return Err(AuthError::StoreIo {
+                path: path.to_path_buf(),
+                source,
+            });
+        }
+    };
+    if bytes.is_empty() {
+        return Ok(DockerConfig::default());
+    }
+    serde_json::from_slice(&bytes).map_err(|source| AuthError::MalformedConfig {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+/// Serialize and atomically replace the docker config, then tighten the
+/// mode to owner-only (`0600`) — credentials must not inherit the `0644`
+/// cap [`atomic_write`] applies to ordinary state files.
+fn write_config(path: &Path, config: &DockerConfig) -> Result<(), AuthError> {
+    let bytes = serde_json::to_vec_pretty(config).map_err(|source| AuthError::MalformedConfig {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    atomic_write(path, &bytes).map_err(|source| AuthError::StoreIo {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    restrict_permissions(path)
+}
+
+/// Ensure the config file (and its parent directory) exist so the advisory
+/// lock has something to open. A freshly created file is owner-only.
+fn ensure_config_file(path: &Path) -> Result<(), AuthError> {
+    let io = |source| AuthError::StoreIo {
+        path: path.to_path_buf(),
+        source,
+    };
+    if let Some(parent) = path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        std::fs::create_dir_all(parent).map_err(io)?;
+    }
+    if !path.exists() {
+        let mut opts = std::fs::OpenOptions::new();
+        opts.write(true).create(true).truncate(false);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt as _;
+            opts.mode(0o600);
+        }
+        opts.open(path).map_err(io)?;
+    }
+    Ok(())
+}
+
+/// Acquire the exclusive advisory lock on the config file, mapping the
+/// lock-subsystem error into an auth-tier store error.
+fn acquire_lock(path: &Path) -> Result<ConfigFileLock, AuthError> {
+    ConfigFileLock::try_acquire(path).map_err(|err| {
+        let source = match err.kind {
+            LockErrorKind::Locked => std::io::Error::new(
+                std::io::ErrorKind::WouldBlock,
+                "credential store is locked by another process",
+            ),
+            LockErrorKind::Io(io) => io,
+            other => std::io::Error::other(other.to_string()),
+        };
+        AuthError::StoreIo {
+            path: path.to_path_buf(),
+            source,
+        }
+    })
+}
+
+#[cfg(unix)]
+fn restrict_permissions(path: &Path) -> Result<(), AuthError> {
+    use std::os::unix::fs::PermissionsExt as _;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600)).map_err(|source| AuthError::StoreIo {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+#[cfg(not(unix))]
+fn restrict_permissions(_path: &Path) -> Result<(), AuthError> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tmp() -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        (dir, path)
+    }
+
+    fn opts(allow_plaintext_put: bool) -> StoreOptions {
+        StoreOptions { allow_plaintext_put }
+    }
+
+    fn rt() -> tokio::runtime::Runtime {
+        tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+    }
+
+    #[test]
+    fn get_returns_none_on_empty_store() {
+        let (_d, path) = tmp();
+        let store = DockerCredentialStore::with_path(path, opts(false));
+        let got = rt().block_on(store.get("ghcr.io"));
+        assert!(matches!(got, Ok(None)), "fresh store must be empty: {got:?}");
+    }
+
+    #[test]
+    fn put_refuses_plaintext_without_opt_in() {
+        let (_d, path) = tmp();
+        let store = DockerCredentialStore::with_path(path, opts(false));
+        let cred = Credential::basic("u", SecretString::from("p"));
+        let res = rt().block_on(store.put("ghcr.io", &cred));
+        assert!(
+            matches!(res, Err(AuthError::NoCredentialStore)),
+            "no helper + no opt-in must refuse: {res:?}"
+        );
+    }
+
+    #[test]
+    fn put_then_get_round_trips_plaintext() {
+        let (_d, path) = tmp();
+        let store = DockerCredentialStore::with_path(path.clone(), opts(true));
+        let cred = Credential::basic("alice", SecretString::from("hunter2"));
+        rt().block_on(store.put("ghcr.io", &cred)).expect("put");
+
+        let raw = std::fs::read_to_string(&path).unwrap();
+        let json: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        let auth = json.pointer("/auths/ghcr.io/auth").and_then(|v| v.as_str()).unwrap();
+        let decoded = String::from_utf8(BASE64.decode(auth).unwrap()).unwrap();
+        assert_eq!(decoded, "alice:hunter2");
+
+        let got = rt().block_on(store.get("ghcr.io")).unwrap().unwrap();
+        assert_eq!(got.username, "alice");
+        assert_eq!(got.password.expose_secret(), "hunter2");
+    }
+
+    #[test]
+    fn put_canonicalizes_registry_key() {
+        let (_d, path) = tmp();
+        let store = DockerCredentialStore::with_path(path.clone(), opts(true));
+        let cred = Credential::basic("u", SecretString::from("p"));
+        rt().block_on(store.put("https://ghcr.io/v2/", &cred)).expect("put");
+        let json: serde_json::Value = serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert!(
+            json.pointer("/auths/ghcr.io/auth").is_some(),
+            "key must be canonical ghcr.io"
+        );
+    }
+
+    #[test]
+    fn delete_removes_plaintext_entry() {
+        let (_d, path) = tmp();
+        let store = DockerCredentialStore::with_path(path.clone(), opts(true));
+        let cred = Credential::basic("u", SecretString::from("p"));
+        rt().block_on(store.put("ghcr.io", &cred)).expect("put");
+        rt().block_on(store.delete("ghcr.io")).expect("delete");
+        let json: serde_json::Value = serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert!(
+            json.pointer("/auths/ghcr.io").is_none(),
+            "entry must be gone after delete"
+        );
+    }
+
+    #[test]
+    fn delete_is_noop_on_absent_store() {
+        let (_d, path) = tmp();
+        let store = DockerCredentialStore::with_path(path, opts(false));
+        assert!(matches!(rt().block_on(store.delete("ghcr.io")), Ok(())));
+    }
+
+    #[test]
+    fn put_preserves_unknown_top_level_keys() {
+        let (_d, path) = tmp();
+        std::fs::write(&path, r#"{"currentContext":"default","experimental":true}"#).unwrap();
+        let store = DockerCredentialStore::with_path(path.clone(), opts(true));
+        let cred = Credential::basic("u", SecretString::from("p"));
+        rt().block_on(store.put("ghcr.io", &cred)).expect("put");
+        let json: serde_json::Value = serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(json.get("currentContext").and_then(|v| v.as_str()), Some("default"));
+        assert_eq!(json.get("experimental").and_then(|v| v.as_bool()), Some(true));
+    }
+
+    #[test]
+    fn malformed_config_surfaces_error() {
+        let (_d, path) = tmp();
+        std::fs::write(&path, "not json {").unwrap();
+        let store = DockerCredentialStore::with_path(path, opts(true));
+        let cred = Credential::basic("u", SecretString::from("p"));
+        let res = rt().block_on(store.put("ghcr.io", &cred));
+        assert!(matches!(res, Err(AuthError::MalformedConfig { .. })), "got: {res:?}");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn plaintext_put_creates_file_mode_0600() {
+        use std::os::unix::fs::PermissionsExt as _;
+        let (_d, path) = tmp();
+        let store = DockerCredentialStore::with_path(path.clone(), opts(true));
+        let cred = Credential::basic("u", SecretString::from("p"));
+        rt().block_on(store.put("ghcr.io", &cred)).expect("put");
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "credentials file must be owner-only");
+    }
+}

--- a/src/command.rs
+++ b/src/command.rs
@@ -14,6 +14,8 @@ pub mod command_error;
 pub mod init;
 pub mod install;
 pub mod lock;
+pub mod login;
+pub mod logout;
 pub mod release;
 pub mod remove;
 pub mod scope_resolution;
@@ -25,6 +27,32 @@ pub mod update;
 
 #[allow(unused_imports)]
 pub use command_error::CommandError;
+
+/// Resolve the registry for `login` / `logout`: an explicit (non-empty)
+/// argument wins, else the context's `default_registry`. A miss is a
+/// classifiable config error, not a panic.
+///
+/// # Errors
+///
+/// [`CommandError::NoLoginRegistry`] when neither an argument nor a
+/// default registry is available.
+pub fn resolve_login_registry(ctx: &crate::context::Context, explicit: Option<&str>) -> anyhow::Result<String> {
+    if let Some(reg) = explicit.filter(|r| !r.is_empty()) {
+        return Ok(reg.to_string());
+    }
+    ctx.default_registry()
+        .map(str::to_string)
+        .ok_or_else(|| anyhow::Error::from(crate::error::Error::from(command_error::CommandError::NoLoginRegistry)))
+}
+
+/// Build a classifiable usage error (exit 64) for a missing `login`
+/// credential input, routed through the top-level error so
+/// [`crate::error::classify_error`] sees it.
+pub fn login_usage(message: &'static str) -> anyhow::Error {
+    anyhow::Error::from(crate::error::Error::from(command_error::CommandError::LoginInput(
+        message,
+    )))
+}
 
 /// Map a subsystem `Result` into an `anyhow::Result` whose error is wrapped
 /// in the top-level [`crate::error::Error`].

--- a/src/command/command_error.rs
+++ b/src/command/command_error.rs
@@ -30,6 +30,16 @@ pub enum CommandError {
     /// `GRIM_DEFAULT_REGISTRY`.
     #[error("no registry to search; pass --registry or set GRIM_DEFAULT_REGISTRY")]
     NoRegistry,
+
+    /// `login` / `logout` need a registry but none was given and no
+    /// default is configured.
+    #[error("no registry given; pass a registry argument or set GRIM_DEFAULT_REGISTRY")]
+    NoLoginRegistry,
+
+    /// `login` could not obtain a required credential input — typically a
+    /// non-interactive shell missing `--username` / `--password-stdin`.
+    #[error("{0}")]
+    LoginInput(&'static str),
 }
 
 #[cfg(test)]

--- a/src/command/login.rs
+++ b/src/command/login.rs
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The Grimoire Authors
+
+//! `grim login` — authenticate to a registry and persist the credential
+//! through the docker-compatible store.
+//!
+//! Username is prompted on a TTY when `--username` is omitted; the
+//! password is read via `--password-stdin` or a hidden TTY prompt. There
+//! is intentionally **no** `--password VALUE` flag — an argv-visible
+//! secret leaks through `ps` and shell history, so it is refused by
+//! construction (clap has no such argument to parse).
+
+use std::io::Read as _;
+
+use clap::Args;
+use secrecy::SecretString;
+use secrecy::zeroize::Zeroizing;
+
+use crate::api::login_report::LoginReport;
+use crate::auth::credential::Credential;
+use crate::auth::login as auth_login;
+use crate::auth::prompt;
+use crate::auth::store::{DockerCredentialStore, StoreOptions};
+use crate::cli::exit_code::ExitCode;
+use crate::context::Context;
+
+/// `grim login` arguments.
+#[derive(Debug, Args)]
+pub struct LoginArgs {
+    /// Account name. Prompted on a TTY when omitted.
+    #[arg(short = 'u', long)]
+    pub username: Option<String>,
+
+    /// Read the password / token from stdin instead of prompting.
+    /// Required when stdin is not a terminal.
+    #[arg(long)]
+    pub password_stdin: bool,
+
+    /// Store the credential as base64 plaintext in
+    /// `~/.docker/config.json` when no credential helper is configured.
+    /// Refused by default.
+    #[arg(long)]
+    pub allow_insecure_store: bool,
+
+    /// Registry hostname (e.g. `ghcr.io`). Falls back to `--registry`,
+    /// the `default_registry` option, or `GRIM_DEFAULT_REGISTRY`.
+    pub registry: Option<String>,
+}
+
+/// Run `grim login`.
+///
+/// # Errors
+///
+/// A missing/empty credential input (usage error 64), a missing registry
+/// (config error 78), or a credential-store failure (auth/I/O tiers).
+pub async fn run(ctx: &Context, args: &LoginArgs) -> anyhow::Result<(LoginReport, ExitCode)> {
+    let registry = super::resolve_login_registry(ctx, args.registry.as_deref())?;
+
+    // Credential input blocks on a TTY / stdin read, so it runs on the
+    // blocking pool — never parking an async worker thread (quality-rust.md).
+    let username = match &args.username {
+        Some(u) => u.clone(),
+        None => {
+            input_task(|| {
+                prompt::prompt_username().map_err(|_| {
+                    super::login_usage("non-interactive login requires --username (-u) when stdin is not a TTY")
+                })
+            })
+            .await?
+        }
+    };
+    if username.is_empty() {
+        return Err(super::login_usage("username must not be empty"));
+    }
+
+    let password_stdin = args.password_stdin;
+    let password = input_task(move || read_password(password_stdin)).await?;
+    let cred = Credential::basic(username.clone(), password);
+
+    let store = super::grim(DockerCredentialStore::new(StoreOptions {
+        allow_plaintext_put: args.allow_insecure_store,
+    }))?;
+    super::grim(auth_login::login(&registry, &cred, &store).await)?;
+
+    Ok((LoginReport::new(registry, username), ExitCode::Success))
+}
+
+/// Run a blocking credential-input closure on the blocking pool. A panic in
+/// the closure is re-raised on the caller thread rather than swallowed.
+async fn input_task<T, F>(f: F) -> anyhow::Result<T>
+where
+    T: Send + 'static,
+    F: FnOnce() -> anyhow::Result<T> + Send + 'static,
+{
+    match tokio::task::spawn_blocking(f).await {
+        Ok(result) => result,
+        Err(join) if join.is_panic() => std::panic::resume_unwind(join.into_panic()),
+        Err(join) => Err(anyhow::anyhow!("credential input task failed: {join}")),
+    }
+}
+
+/// Read the password from stdin (`--password-stdin`) or a hidden TTY
+/// prompt. Empty input is rejected as a usage error in both modes. Called
+/// inside [`input_task`] — blocking by design.
+fn read_password(password_stdin: bool) -> anyhow::Result<SecretString> {
+    if password_stdin {
+        // Zeroized so the cleartext password does not linger on the heap
+        // after it is wrapped in `SecretString`.
+        let mut buf = Zeroizing::new(String::new());
+        std::io::stdin().read_to_string(&mut buf).map_err(|source| {
+            // I/O failure → IoError(74) via the classified store error, not
+            // the generic Failure(1) a bare anyhow error would yield.
+            anyhow::Error::from(crate::error::Error::from(crate::auth::auth_error::AuthError::StoreIo {
+                path: std::path::PathBuf::from("<stdin>"),
+                source,
+            }))
+        })?;
+        // Strip a single trailing newline (the common `echo "$TOKEN" |`
+        // case); a password is otherwise taken verbatim.
+        let pass = buf.strip_suffix('\n').unwrap_or(&buf);
+        let pass = pass.strip_suffix('\r').unwrap_or(pass);
+        if pass.is_empty() {
+            return Err(super::login_usage("--password-stdin received empty input"));
+        }
+        Ok(SecretString::from(pass.to_string()))
+    } else {
+        let pass = prompt::prompt_password()
+            .map_err(|_| super::login_usage("non-interactive login requires --password-stdin (stdin is not a TTY)"))?;
+        if secrecy::ExposeSecret::expose_secret(&pass).is_empty() {
+            return Err(super::login_usage("password must not be empty"));
+        }
+        Ok(pass)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser as _;
+
+    /// Helper harness so clap can parse the subcommand args in isolation.
+    #[derive(clap::Parser)]
+    struct Harness {
+        #[command(subcommand)]
+        cmd: Sub,
+    }
+
+    #[derive(clap::Subcommand)]
+    enum Sub {
+        Login(LoginArgs),
+    }
+
+    fn parse(args: &[&str]) -> Result<LoginArgs, clap::Error> {
+        let mut argv = vec!["grim", "login"];
+        argv.extend_from_slice(args);
+        Harness::try_parse_from(argv).map(|h| match h.cmd {
+            Sub::Login(a) => a,
+        })
+    }
+
+    #[test]
+    fn rejects_password_value_flag() {
+        // CWE-214: there is no `--password VALUE`; clap must reject it.
+        assert!(parse(&["--password", "x", "ghcr.io"]).is_err());
+    }
+
+    #[test]
+    fn accepts_minimal_and_full_invocations() {
+        parse(&["ghcr.io"]).expect("bare positional parses");
+        parse(&["-u", "user", "--password-stdin", "--allow-insecure-store", "ghcr.io"]).expect("full flag set parses");
+    }
+
+    #[test]
+    fn registry_is_optional_at_parse() {
+        parse(&[]).expect("registry optional (resolved at runtime)");
+    }
+}

--- a/src/command/logout.rs
+++ b/src/command/logout.rs
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The Grimoire Authors
+
+//! `grim logout` — remove a registry credential from the
+//! docker-compatible store.
+//!
+//! Idempotent: logging out when nothing is stored (or when no store can
+//! even be located) exits `Success(0)`, matching `docker logout` /
+//! `oras logout` so CI cleanup never fails.
+
+use clap::Args;
+
+use crate::api::login_report::LogoutReport;
+use crate::auth::login as auth_login;
+use crate::auth::store::{DockerCredentialStore, StoreOptions};
+use crate::cli::exit_code::ExitCode;
+use crate::context::Context;
+
+/// `grim logout` arguments.
+#[derive(Debug, Args)]
+pub struct LogoutArgs {
+    /// Registry hostname (e.g. `ghcr.io`). Falls back to `--registry`,
+    /// the `default_registry` option, or `GRIM_DEFAULT_REGISTRY`.
+    pub registry: Option<String>,
+}
+
+/// Run `grim logout`.
+///
+/// # Errors
+///
+/// A missing registry (config error 78) or a genuine credential-store
+/// failure during erase (auth/I/O tiers). An absent credential is not an
+/// error.
+pub async fn run(ctx: &Context, args: &LogoutArgs) -> anyhow::Result<(LogoutReport, ExitCode)> {
+    let registry = super::resolve_login_registry(ctx, args.registry.as_deref())?;
+
+    // When no store location can be resolved (no $HOME, no $DOCKER_CONFIG)
+    // there is nothing to log out from — a true no-op, exit 0.
+    match DockerCredentialStore::new(StoreOptions::default()) {
+        Ok(store) => super::grim(auth_login::logout(&registry, &store).await)?,
+        Err(err) => tracing::debug!(%err, "logout: no credential store to act on; treating as no-op"),
+    }
+
+    Ok((LogoutReport::new(registry), ExitCode::Success))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser as _;
+
+    #[derive(clap::Parser)]
+    struct Harness {
+        #[command(subcommand)]
+        cmd: Sub,
+    }
+
+    #[derive(clap::Subcommand)]
+    enum Sub {
+        Logout(LogoutArgs),
+    }
+
+    fn parse(args: &[&str]) -> Result<LogoutArgs, clap::Error> {
+        let mut argv = vec!["grim", "logout"];
+        argv.extend_from_slice(args);
+        Harness::try_parse_from(argv).map(|h| match h.cmd {
+            Sub::Logout(a) => a,
+        })
+    }
+
+    #[test]
+    fn registry_is_optional_and_positional() {
+        parse(&[]).expect("registry optional");
+        let a = parse(&["ghcr.io"]).expect("positional registry parses");
+        assert_eq!(a.registry.as_deref(), Some("ghcr.io"));
+    }
+}

--- a/src/env.rs
+++ b/src/env.rs
@@ -16,6 +16,9 @@ const GRIM_DEFAULT_REGISTRY: &str = "GRIM_DEFAULT_REGISTRY";
 const GRIM_OFFLINE: &str = "GRIM_OFFLINE";
 /// Environment variable that, when truthy, routes lookups to the remote.
 const GRIM_REMOTE: &str = "GRIM_REMOTE";
+/// Docker-compatible config directory override, honoured by `grim login`
+/// / `grim logout` and the credential read path for parity with `docker`.
+const DOCKER_CONFIG: &str = "DOCKER_CONFIG";
 
 /// Resolves the Grimoire data root.
 ///
@@ -46,6 +49,19 @@ pub fn offline() -> bool {
 /// Whether remote routing is requested via `$GRIM_REMOTE`.
 pub fn remote() -> bool {
     truthy(GRIM_REMOTE)
+}
+
+/// Resolves the docker-compatible credential config path.
+///
+/// `$DOCKER_CONFIG/config.json` when `$DOCKER_CONFIG` is set and
+/// non-empty, otherwise `~/.docker/config.json`. Returns `None` when
+/// neither `$DOCKER_CONFIG` nor a home directory can be determined — the
+/// caller surfaces that as a configuration error.
+pub fn docker_config_path() -> Option<PathBuf> {
+    if let Some(dir) = non_empty_var(DOCKER_CONFIG) {
+        return Some(PathBuf::from(dir).join("config.json"));
+    }
+    home_dir().map(|home| home.join(".docker").join("config.json"))
 }
 
 fn non_empty_var(key: &str) -> Option<String> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,6 +8,7 @@
 //! taxonomy. It walks the `anyhow` chain, downcasts to [`Error`], and maps
 //! each known kind to a typed [`ExitCode`].
 
+use crate::auth::auth_error::AuthError;
 use crate::catalog::catalog_error::{CatalogError, CatalogErrorKind};
 use crate::cli::exit_code::ExitCode;
 use crate::command::command_error::CommandError;
@@ -63,6 +64,9 @@ pub enum Error {
     Catalog(#[from] CatalogError),
 
     #[error(transparent)]
+    Auth(#[from] AuthError),
+
+    #[error(transparent)]
     Command(#[from] CommandError),
 }
 
@@ -89,10 +93,12 @@ pub fn classify_error(err: &anyhow::Error) -> ExitCode {
                 Error::Skill(se) => classify_skill(se),
                 Error::Release(re) => classify_release(re),
                 Error::Catalog(ce) => classify_catalog(ce),
+                Error::Auth(ae) => classify_auth(ae),
                 Error::Command(ce) => match ce {
                     CommandError::LockMissing { .. } => ExitCode::NotFound,
                     CommandError::LockStale { .. } => ExitCode::DataError,
-                    CommandError::NoRegistry => ExitCode::ConfigError,
+                    CommandError::NoRegistry | CommandError::NoLoginRegistry => ExitCode::ConfigError,
+                    CommandError::LoginInput(_) => ExitCode::UsageError,
                 },
             };
         }
@@ -195,6 +201,33 @@ fn classify_catalog(err: &CatalogError) -> ExitCode {
     }
 }
 
+/// Map an auth-tier error to an exit code. Store I/O delegates to the I/O
+/// classifier; malformed on-disk config is bad data (65); a missing store
+/// or config location is a configuration problem (78); helper failures map
+/// per the underlying `docker_credential` error kind.
+fn classify_auth(err: &AuthError) -> ExitCode {
+    use docker_credential::CredentialRetrievalError as Helper;
+    match err {
+        AuthError::StoreIo { source, .. } => classify_io(source),
+        AuthError::MalformedConfig { .. } => ExitCode::DataError,
+        AuthError::NoCredentialStore | AuthError::NoConfigLocation => ExitCode::ConfigError,
+        AuthError::HelperFailed { .. } => ExitCode::AuthError,
+        AuthError::Helper(inner) => match inner {
+            Helper::NotOnPath { .. } | Helper::UnsafePath { .. } => ExitCode::ConfigError,
+            Helper::Timeout { .. } => ExitCode::TempFail,
+            Helper::InvalidJson(_) | Helper::MalformedHelperResponse | Helper::CredentialDecodingError => {
+                ExitCode::DataError
+            }
+            Helper::HelperCommunicationError => ExitCode::IoError,
+            // OutputTooLarge / HelperFailure / the config-miss sentinels are
+            // all treated as auth failures (the miss variants are never
+            // wrapped in `Helper` — `map_helper_err`/`get_blocking` divert
+            // them — but the arm keeps the match total).
+            _ => ExitCode::AuthError,
+        },
+    }
+}
+
 /// `PermissionDenied` → `NoPermission` (77); any other I/O → `IoError` (74).
 fn classify_io(io: &std::io::Error) -> ExitCode {
     if io.kind() == std::io::ErrorKind::PermissionDenied {
@@ -217,6 +250,70 @@ mod tests {
         let inner = IdentifierError::new("bad", IdentifierErrorKind::MissingRegistry);
         let err: anyhow::Error = Error::from(inner).into();
         assert_eq!(classify_error(&err), ExitCode::DataError);
+    }
+
+    #[test]
+    fn auth_errors_classify_per_kind() {
+        let cases = [
+            (
+                AuthError::StoreIo {
+                    path: std::path::PathBuf::from("/x/config.json"),
+                    source: std::io::Error::other("disk full"),
+                },
+                ExitCode::IoError,
+            ),
+            (
+                AuthError::StoreIo {
+                    path: std::path::PathBuf::from("/x/config.json"),
+                    source: std::io::Error::from(std::io::ErrorKind::PermissionDenied),
+                },
+                ExitCode::NoPermission,
+            ),
+            (
+                AuthError::MalformedConfig {
+                    path: std::path::PathBuf::from("/x/config.json"),
+                    source: serde_json::from_str::<serde_json::Value>("{").expect_err("must err"),
+                },
+                ExitCode::DataError,
+            ),
+            (AuthError::NoCredentialStore, ExitCode::ConfigError),
+            (AuthError::NoConfigLocation, ExitCode::ConfigError),
+            (
+                AuthError::HelperFailed {
+                    helper: "test".to_string(),
+                },
+                ExitCode::AuthError,
+            ),
+        ];
+        for (inner, expected) in cases {
+            let err: anyhow::Error = Error::from(inner).into();
+            assert_eq!(classify_error(&err), expected);
+        }
+    }
+
+    #[test]
+    fn helper_error_kinds_classify_per_variant() {
+        use docker_credential::CredentialRetrievalError as Helper;
+        let cases = [
+            (Helper::NotOnPath { name: "x".into() }, ExitCode::ConfigError),
+            (Helper::Timeout { seconds: 30 }, ExitCode::TempFail),
+            (Helper::MalformedHelperResponse, ExitCode::DataError),
+            (Helper::CredentialDecodingError, ExitCode::DataError),
+            (Helper::HelperCommunicationError, ExitCode::IoError),
+        ];
+        for (helper, expected) in cases {
+            let err: anyhow::Error = Error::from(AuthError::Helper(helper)).into();
+            assert_eq!(classify_error(&err), expected);
+        }
+    }
+
+    #[test]
+    fn command_login_errors_classify_per_kind() {
+        let no_registry: anyhow::Error = Error::from(CommandError::NoLoginRegistry).into();
+        assert_eq!(classify_error(&no_registry), ExitCode::ConfigError);
+
+        let usage: anyhow::Error = Error::from(CommandError::LoginInput("bad input")).into();
+        assert_eq!(classify_error(&usage), ExitCode::UsageError);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@
 
 mod api;
 mod app;
+mod auth;
 mod catalog;
 mod cli;
 mod command;
@@ -44,6 +45,8 @@ use crate::command::build::BuildArgs;
 use crate::command::init::InitArgs;
 use crate::command::install::InstallArgs;
 use crate::command::lock::LockArgs;
+use crate::command::login::LoginArgs;
+use crate::command::logout::LogoutArgs;
 use crate::command::release::ReleaseArgs;
 use crate::command::remove::RemoveArgs;
 use crate::command::search::SearchArgs;
@@ -95,6 +98,10 @@ pub enum Command {
     Search(SearchArgs),
     /// Browse the registry catalog in an interactive TUI.
     Tui(TuiArgs),
+    /// Authenticate to a registry and store the credential.
+    Login(LoginArgs),
+    /// Remove a stored registry credential.
+    Logout(LogoutArgs),
 }
 
 fn main() -> std::process::ExitCode {

--- a/src/oci/access/registry_client.rs
+++ b/src/oci/access/registry_client.rs
@@ -93,13 +93,22 @@ impl RegistryClient {
     fn auth_for(registry: &str) -> Result<RegistryAuth, AccessErrorKind> {
         use docker_credential::{CredentialRetrievalError, DockerCredential};
 
-        match docker_credential::get_credential(registry) {
+        // Canonicalize the lookup key so a credential written by
+        // `grim login` (scheme / `/vN` stripped, docker.io aliased) is
+        // found here. Single source of truth: `auth::canonicalize_registry`.
+        let registry = crate::auth::canonicalize_registry(registry);
+        match docker_credential::get_credential(&registry) {
             Ok(DockerCredential::IdentityToken(token)) => Ok(RegistryAuth::Bearer(token)),
             Ok(DockerCredential::UsernamePassword(user, pass)) => Ok(RegistryAuth::Basic(user, pass)),
+            // "No credential for this registry" is a benign anonymous-access
+            // case, not an error. The patched `docker_credential` fork
+            // surfaces a credential-helper miss as `NotFound` (upstream rolled
+            // it into `HelperFailure`), so it joins the anonymous group too.
             Err(
                 CredentialRetrievalError::NoCredentialConfigured
                 | CredentialRetrievalError::ConfigNotFound
                 | CredentialRetrievalError::ConfigReadError
+                | CredentialRetrievalError::NotFound
                 | CredentialRetrievalError::HelperFailure { .. },
             ) => Ok(RegistryAuth::Anonymous),
             Err(e) => Err(AccessErrorKind::Authentication(Box::new(e))),

--- a/test/tests/test_login.py
+++ b/test/tests/test_login.py
@@ -1,0 +1,318 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 The Grimoire Authors
+"""Acceptance tests for ``grim login`` / ``grim logout``.
+
+Every test isolates the docker config into a per-test ``DOCKER_CONFIG``
+tempdir — the user's real ``~/.docker`` is never touched. Helper-backed
+tests drop a ``docker-credential-test`` Python script onto a tempdir,
+prepend it to ``PATH``, and point ``credsStore`` at ``test``.
+
+Exit codes follow ``quality-rust-exit_codes.md`` (sysexits-aligned):
+usage 64, config 78, success 0.
+"""
+from __future__ import annotations
+
+import base64
+import json
+import os
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from src.runner import GrimRunner
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def docker_config(tmp_path: Path) -> Path:
+    """An isolated ``$DOCKER_CONFIG`` directory."""
+    d = tmp_path / "docker"
+    d.mkdir()
+    return d
+
+
+_MOCK_HELPER = """\
+#!/usr/bin/env python3
+import json, os, sys
+
+store = os.environ["DOCKER_CREDENTIAL_TEST_STORE"]
+
+
+def load():
+    try:
+        with open(store) as fh:
+            return json.load(fh)
+    except FileNotFoundError:
+        return {}
+
+
+def save(data):
+    with open(store, "w") as fh:
+        json.dump(data, fh)
+
+
+action = sys.argv[1] if len(sys.argv) > 1 else ""
+data = load()
+
+if action == "store":
+    req = json.load(sys.stdin)
+    data[req["ServerURL"]] = {"Username": req["Username"], "Secret": req["Secret"]}
+    save(data)
+elif action == "get":
+    server = sys.stdin.read().strip()
+    entry = data.get(server)
+    if entry is None:
+        print("credentials not found in native keychain")
+        sys.exit(1)
+    print(json.dumps({"ServerURL": server, "Username": entry["Username"], "Secret": entry["Secret"]}))
+elif action == "erase":
+    server = sys.stdin.read().strip()
+    data.pop(server, None)
+    save(data)
+elif action == "list":
+    print(json.dumps({k: v["Username"] for k, v in data.items()}))
+else:
+    sys.exit(2)
+"""
+
+
+@pytest.fixture()
+def credential_helper(tmp_path: Path, docker_config: Path) -> dict[str, str]:
+    """A ``docker-credential-test`` helper on PATH + a ``credsStore`` config.
+
+    Returns the extra environment the runner needs and writes the seed
+    config.json. The helper persists credentials to a JSON file named by
+    ``DOCKER_CREDENTIAL_TEST_STORE``.
+    """
+    bin_dir = tmp_path / "helper-bin"
+    bin_dir.mkdir()
+    helper = bin_dir / "docker-credential-test"
+    helper.write_text(_MOCK_HELPER)
+    helper.chmod(helper.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+    (docker_config / "config.json").write_text(json.dumps({"credsStore": "test"}))
+
+    store_file = tmp_path / "helper-store.json"
+    return {
+        "PATH": f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}",
+        "DOCKER_CREDENTIAL_TEST_STORE": str(store_file),
+        "_STORE_FILE": str(store_file),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _login(
+    grim: GrimRunner,
+    *args: str,
+    docker_config: Path,
+    stdin: str | None = None,
+    extra_env: dict[str, str] | None = None,
+    fmt: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    env = dict(grim.env)
+    env["DOCKER_CONFIG"] = str(docker_config)
+    if extra_env:
+        env.update({k: v for k, v in extra_env.items() if not k.startswith("_")})
+    cmd = [str(grim.binary)]
+    if fmt:
+        cmd += ["--format", fmt]
+    cmd += ["login", *args]
+    return subprocess.run(
+        cmd,
+        input=stdin,
+        stdin=subprocess.DEVNULL if stdin is None else None,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def _logout(
+    grim: GrimRunner,
+    *args: str,
+    docker_config: Path,
+    extra_env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    env = dict(grim.env)
+    env["DOCKER_CONFIG"] = str(docker_config)
+    if extra_env:
+        env.update({k: v for k, v in extra_env.items() if not k.startswith("_")})
+    return subprocess.run(
+        [str(grim.binary), "logout", *args],
+        stdin=subprocess.DEVNULL,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def _read_config(docker_config: Path) -> dict:
+    path = docker_config / "config.json"
+    return json.loads(path.read_text()) if path.exists() else {}
+
+
+# ---------------------------------------------------------------------------
+# Plaintext-store path (no native helper)
+# ---------------------------------------------------------------------------
+
+
+def test_login_plaintext_writes_base64_entry(grim: GrimRunner, docker_config: Path) -> None:
+    res = _login(
+        grim,
+        "-u", "alice", "--password-stdin", "--allow-insecure-store", "ghcr.io",
+        docker_config=docker_config,
+        stdin="hunter2\n",
+    )
+    assert res.returncode == 0, res.stderr
+    cfg = _read_config(docker_config)
+    auth = cfg["auths"]["ghcr.io"]["auth"]
+    assert base64.b64decode(auth).decode() == "alice:hunter2"
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX file mode check")
+def test_login_plaintext_config_is_owner_only(grim: GrimRunner, docker_config: Path) -> None:
+    _login(
+        grim,
+        "-u", "u", "--password-stdin", "--allow-insecure-store", "ghcr.io",
+        docker_config=docker_config,
+        stdin="p\n",
+    )
+    mode = (docker_config / "config.json").stat().st_mode & 0o777
+    assert mode == 0o600, f"credentials file must be 0600, got {oct(mode)}"
+
+
+def test_login_refused_without_helper_or_optin(grim: GrimRunner, docker_config: Path) -> None:
+    res = _login(
+        grim,
+        "-u", "u", "--password-stdin", "ghcr.io",
+        docker_config=docker_config,
+        stdin="p\n",
+    )
+    assert res.returncode == 78, res.stderr  # ConfigError
+    assert "allow-insecure-store" in res.stderr or "credential helper" in res.stderr
+
+
+def test_login_canonicalizes_registry_key(grim: GrimRunner, docker_config: Path) -> None:
+    res = _login(
+        grim,
+        "-u", "u", "--password-stdin", "--allow-insecure-store", "https://ghcr.io/v1/",
+        docker_config=docker_config,
+        stdin="p\n",
+    )
+    assert res.returncode == 0, res.stderr
+    cfg = _read_config(docker_config)
+    assert "ghcr.io" in cfg["auths"], cfg
+
+
+# ---------------------------------------------------------------------------
+# Usage / input errors
+# ---------------------------------------------------------------------------
+
+
+def test_login_noninteractive_requires_password_stdin(grim: GrimRunner, docker_config: Path) -> None:
+    # No --password-stdin and stdin is /dev/null (not a TTY) → usage error.
+    res = _login(grim, "-u", "u", "--allow-insecure-store", "ghcr.io", docker_config=docker_config)
+    assert res.returncode == 64, res.stderr  # UsageError
+    assert "--password-stdin" in res.stderr
+
+
+def test_login_rejects_password_value_flag(grim: GrimRunner, docker_config: Path) -> None:
+    # CWE-214: there is no --password VALUE flag; clap rejects it at parse.
+    res = _login(grim, "--password", "secret", "ghcr.io", docker_config=docker_config)
+    assert res.returncode == 64, res.stderr
+
+
+def test_login_empty_password_stdin_is_usage_error(grim: GrimRunner, docker_config: Path) -> None:
+    res = _login(
+        grim,
+        "-u", "u", "--password-stdin", "--allow-insecure-store", "ghcr.io",
+        docker_config=docker_config,
+        stdin="",
+    )
+    assert res.returncode == 64, res.stderr
+
+
+# ---------------------------------------------------------------------------
+# JSON output
+# ---------------------------------------------------------------------------
+
+
+def test_login_json_output(grim: GrimRunner, docker_config: Path) -> None:
+    res = _login(
+        grim,
+        "-u", "alice", "--password-stdin", "--allow-insecure-store", "ghcr.io",
+        docker_config=docker_config,
+        stdin="p\n",
+        fmt="json",
+    )
+    assert res.returncode == 0, res.stderr
+    payload = json.loads(res.stdout)
+    assert payload == {"registry": "ghcr.io", "username": "alice"}
+
+
+# ---------------------------------------------------------------------------
+# Logout
+# ---------------------------------------------------------------------------
+
+
+def test_logout_removes_plaintext_entry(grim: GrimRunner, docker_config: Path) -> None:
+    _login(
+        grim,
+        "-u", "u", "--password-stdin", "--allow-insecure-store", "ghcr.io",
+        docker_config=docker_config,
+        stdin="p\n",
+    )
+    res = _logout(grim, "ghcr.io", docker_config=docker_config)
+    assert res.returncode == 0, res.stderr
+    assert "ghcr.io" not in _read_config(docker_config).get("auths", {})
+
+
+def test_logout_noop_when_nothing_stored(grim: GrimRunner, docker_config: Path) -> None:
+    res = _logout(grim, "ghcr.io", docker_config=docker_config)
+    assert res.returncode == 0, res.stderr
+
+
+# ---------------------------------------------------------------------------
+# Native-helper path (mock docker-credential-test)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="mock helper is a POSIX script")
+def test_login_via_helper_stores_credential(grim: GrimRunner, docker_config: Path, credential_helper: dict) -> None:
+    res = _login(
+        grim,
+        "-u", "alice", "--password-stdin", "ghcr.io",
+        docker_config=docker_config,
+        stdin="s3cret\n",
+        extra_env=credential_helper,
+    )
+    assert res.returncode == 0, res.stderr
+    # Credential landed in the helper's backing store, NOT in plaintext auths.
+    store = json.loads(Path(credential_helper["_STORE_FILE"]).read_text())
+    assert store["ghcr.io"] == {"Username": "alice", "Secret": "s3cret"}
+    assert "auths" not in _read_config(docker_config)
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="mock helper is a POSIX script")
+def test_logout_via_helper_erases_credential(grim: GrimRunner, docker_config: Path, credential_helper: dict) -> None:
+    _login(
+        grim,
+        "-u", "alice", "--password-stdin", "ghcr.io",
+        docker_config=docker_config,
+        stdin="s3cret\n",
+        extra_env=credential_helper,
+    )
+    res = _logout(grim, "ghcr.io", docker_config=docker_config, extra_env=credential_helper)
+    assert res.returncode == 0, res.stderr
+    store = json.loads(Path(credential_helper["_STORE_FILE"]).read_text())
+    assert "ghcr.io" not in store


### PR DESCRIPTION
## What

Adds `grim login` / `grim logout` so credentials can be **written** to the
docker-compatible credential store. Grimoire already *read* credentials for
pulls (`oci::access::registry_client`); this adds the write/erase half.

Built in Grimoire's style — **not** OCX's architecture: no lib/CLI workspace
split, no credential pre-verify seam, no native-helper auto-detect. It does
reuse OCX's **patched `docker_credential` fork** (vendored as a submodule +
`[patch.crates-io]`), which adds the `store`/`erase`/`detect` helpers upstream
lacks. Only Grimoire depends on that crate (oci-client 0.16 does not), so the
patch is self-contained.

## Highlights

- **`src/auth/`** subsystem: `Credential` (secrets in `secrecy::SecretString`),
  `DockerCredentialStore` over `~/.docker/config.json` (reuses `ConfigFileLock`
  + `atomic_write`, enforces `0600`), `login`/`logout` ops, registry
  canonicalization, TTY prompts (`rpassword`).
- **`grim login`**: `-u/--username` (prompted on a TTY), `--password-stdin` or
  hidden prompt, `--allow-insecure-store`. No `--password <value>` flag —
  argv-visible secrets are refused by construction.
- **`grim logout`**: idempotent (exit 0 when nothing is stored).
- Helper tiers (`credHelpers` → `credsStore`) take priority over the gated
  plaintext fallback. `AuthError` wired into the sysexits exit-code taxonomy.
- Read path now canonicalizes its lookup key so a login round-trips on resolve.

## Review

An adversarial multi-dimension review (security / correctness / async /
conformance / reuse, each finding independently verified) found 15 confirmed
issues; all actionable ones are fixed in this branch:

- **block** helper stdout/stderr log leak (CWE-532) → redacted at the boundary
- **block** blocking TTY/stdin reads on the async worker → `spawn_blocking`
- **block** panic in `spawn_blocking` masked as I/O → `resume_unwind`
- **warn** logout TOCTOU, classify coverage + tests, stdin-error classification,
  dead re-exports, `Zeroizing` of transient cleartext
- **suggest** flock no longer held across the helper subprocess

## Testing

- Rust unit tests (incl. store/credential/classify/command-parse).
- pytest acceptance (`test/tests/test_login.py`): plaintext round-trip + `0600`,
  refusal without opt-in, usage errors, JSON output, logout no-op, and a mock
  native credential helper for the store/erase path.
- Full `task verify` green.

## Note for reviewers / CI

This branch adds a git **submodule** at `external/docker_credential`. CI
checkout must use `submodules: true` (or `recursive`) for the `[patch.crates-io]`
path to resolve.