### PR TITLE
feat: VS Code extension API — describe, binary fetch, replaced-by

### DIFF
--- a/.claude/artifacts/adr_description_companion.md
+++ b/.claude/artifacts/adr_description_companion.md
@@ -1,0 +1,239 @@
+# ADR: Repository description companion v2 — publish.toml integration + fetch read surface
+
+## Metadata
+
+**Status:** Accepted
+**Date:** 2026-07-12
+**Deciders:** Michael Herwig (maintainer)
+**Tech Strategy Alignment:**
+- [x] Decision follows Golden Path in `.claude/rules/product-tech-strategy.md`
+      (OCI substrate, existing tar/fetch machinery, no new crates)
+**Domain Tags:** api, integration
+**Supersedes:** the v1 `desc` surface shipped on `feat/vscode-extension-api`
+(commits `706b307`, `bcee7ba` — unmerged PR #33, so this is a clean rework,
+no compat shims per pre-1.0 policy)
+
+## Context
+
+The VS Code extension shows a details tab (README, logo, CHANGELOG,
+metadata) for **every** artifact kind. The in-tree README channel only
+reaches tar-backed kinds — mcp and bundle publish a single JSON layer with
+no file tree. v1 added a repository-level description companion: a tar
+layer at the reserved `__grimoire` tag, marked `com.grimoire.kind: desc`.
+
+v1 review surfaced five problems:
+
+1. **Magic tag leaks to callers** — the extension hardcodes
+   `repo:__grimoire` refs; an internal convention became a consumer API.
+2. **Command sprawl** — `grim desc publish` added a near-collision noun
+   beside `grim describe`, and the read path had no command at all.
+3. **Publish UX is under-designed** — "pack whatever is in `--dir
+   description/`" forces a non-standard repo layout and gives no
+   source→packed mapping. README.md was arbitrarily required.
+4. **No cheap cache probe** — the extension re-downloads describe + content
+   + companion on every details view; it needs a digest-only call to skip
+   unchanged downloads.
+5. **Read granularity wrong** — the companion is one bundle, but reading it
+   took one fetch plus per-file `--path` follow-ups (up to 3 calls).
+
+## Decision Drivers
+
+- Extension latency: warm-cache details view should cost HEAD requests, not
+  layer downloads
+- Command surface pressure (20+ subcommands): no new top-level nouns
+- Internal conventions (`__grimoire`) must not be typed by consumers
+- Standard repo layout (`README.md`, `assets/logo.png`) over tool-specific
+  directories
+- Deterministic, CAS-idempotent publishing (byte-stable republish = no-op)
+- GitLab compatibility: no custom `artifactType` on the wire
+  (`adr_oci_empty_config_compat.md`)
+
+## Industry Context & Research
+
+**Research basis:** live exploration of `~/dev/ocx` (the `__ocx.desc`
+precursor) and `~/dev/grimoire-vscode` (the consumer) — session 2026-07-12.
+
+- **ocx `__ocx.desc`**: OCI manifest with a typed layer *per file*
+  (`application/markdown` README layer + logo layer, custom
+  `artifactType`, title annotations), merge-on-update publish, repo-level
+  title/description/keywords annotations. Rejected pieces: custom
+  `artifactType` (GitLab), layer-per-file (second read path, more round
+  trips), companion metadata (duplicates grim's per-version manifest
+  annotations), merge-on-update (conflicts with deterministic
+  whole-assembly publish).
+- **VS Code extensions / Cargo / npm**: manifest-declared docs assembly
+  (`package.json` + `.vscodeignore`, `readme = "README.md"`, `files`
+  allowlist) — the mainstream pattern for "tool assembles docs from
+  standard repo layout, manifest overrides".
+- **Extension consumption today** (`grimoire-vscode/src/grim.ts`,
+  `details.ts`): hardcodes `DESC_TAG = '__grimoire'`, blind-probes the
+  companion, then up to two `--path` follow-ups for logo/CHANGELOG; only
+  structured error discriminators used are `error.reason` and exit 64.
+
+**Key insight:** the wire format was right; the authoring and read
+surfaces around it were ad hoc.
+
+## Considered Options
+
+### Option 1: Keep v1 surface (desc publish + raw tag fetch)
+
+| Pros | Cons |
+|------|------|
+| Already implemented | Magic tag is the consumer API |
+| — | Command sprawl, no read command, README required, no cache probe |
+
+### Option 2: Dedicated noun command (`grim description fetch|publish`)
+
+| Pros | Cons |
+|------|------|
+| Symmetric read/write, full-word naming | Still a new top-level command |
+| Hides the tag | `describe`/`description` confusable in help listing |
+
+### Option 3: Fold into existing commands (chosen)
+
+Write rides `grim publish` (manifest-driven); read rides `grim fetch`
+flags; `grim describe` reports presence.
+
+| Pros | Cons |
+|------|------|
+| Zero new top-level commands | `fetch` gains modes (flag interplay to document) |
+| Tag fully internal | Publish behavior change (auto-companion, opt-out) |
+| Digest probe composes for artifact AND companion | — |
+
+## Decision Outcome
+
+**Chosen Option:** 3.
+
+### 1. Wire format (unchanged from v1)
+
+Single deterministic tar layer at the reserved `__grimoire` tag,
+`com.grimoire.kind: desc` annotation as sole discriminator, `__grimoire.<x>`
+family reserved for future companions, internal tags hidden from all
+user-facing listings (`is_internal_tag`). Not an `ArtifactKind`.
+
+**Content contract:**
+- Well-known packed names: `README.md`, `logo.png` | `logo.svg`,
+  `CHANGELOG.md`. Free-form assets (README-referenced images) allowed.
+- **All members optional** (v1's README-required gate is dropped); an
+  empty companion is a data error (65).
+- **No metadata in the companion.** Summary/keywords/license/etc. stay on
+  the per-version artifact manifest (read via `grim describe`). One home
+  per datum — versioned metadata on the manifest, repo-level docs on the
+  companion.
+
+### 2. Write: `publish.toml` is the source of truth
+
+```toml
+[description]                # optional; paths relative to publish.toml
+readme    = "README.md"
+logo      = "assets/logo.png"
+changelog = "CHANGELOG.md"
+include   = ["docs/img/*.png"]   # extra assets
+# publish = false            # top-level kill switch
+
+[skills.grim-usage]
+repository = "grimoire-rs/skills/grim-usage"
+[skills.grim-usage.description]      # per-entry override (same schema)
+readme = "skills/grim-usage/README.md"
+
+[mcp.grim]
+repository = "grimoire-rs/mcp/grim"
+description = false                  # per-entry opt-out
+```
+
+- **Fan-out:** top-level `[description]` publishes to **every** entry's
+  repository; a per-entry `description` table overrides; `description =
+  false` opts an entry out.
+- **Convention fallback:** with no `[description]`, grim probes the
+  manifest directory for `README.md`, `CHANGELOG.md`,
+  `assets/logo.png|svg`, `logo.png|svg`. Any hit → companion publishes by
+  default (opt out with `publish = false`). Source names map to well-known
+  packed names, decoupling repo layout from wire layout.
+- Companion pushes ride the `grim publish` batch, after the entry's
+  artifact pushes. The companion tag is mutable metadata: always re-point;
+  unchanged content ⇒ identical digest ⇒ idempotent no-op (not gated by
+  skip-existing).
+- `grim desc` (the v1 command) is **removed**. Docs-only update = re-run
+  `grim publish` (artifacts skip-existing, companion re-points).
+  `grim release --desc` is deferred until demand shows (YAGNI).
+
+### 3. Read: `grim fetch` flags — the tag never leaves grim
+
+```
+grim fetch <ref> --description             # companion bundle
+grim fetch <ref> --description --out <dir> # plain: unpack tree to dir
+grim fetch <ref> [--description] --digest-only   # cheap probe, no download
+```
+
+- `--description` retargets the reference's repository to the internal
+  companion tag. JSON: **all files inline** —
+  `{ref, digest, kind: "desc", files: [{path, size, content, encoding?}]}`
+  (`encoding: "base64"` for binary, same convention as fetch `--path`).
+  Bounded by the existing 8 MiB layer gate. Plain mode requires `--out`
+  (a multi-file bundle has no single payload to print).
+- `--digest-only` resolves the tag and reports `{ref, digest}` without
+  downloading — one HEAD-equivalent. Composes with `--description` to
+  probe the companion tag. This is the extension's cache key: one manifest
+  digest covers both annotations and content, so a matching digest skips
+  `describe` + `fetch` entirely.
+- `--path` composes with `--description` through the shared fetch core
+  (works, not the documented contract). `--out` is only valid with
+  `--description`.
+- Missing companion → not-found (79) parity with fetch; offline uncached →
+  offline-blocked (81).
+- `grim describe` gains `has_description: bool` — derived from the tag
+  listing it already fetches, zero extra network. Consumers skip the blind
+  probe. (Named `has_description` because `DescribeReport.description`
+  already carries the description-text annotation — presence flag must not
+  collide with it; existing metadata fields stay unchanged.)
+- MCP parity: `grim_fetch` tool args gain `description` / `digest_only`
+  (no `--out` — writes stay in `grim_render`); `grim_describe` report
+  gains the `has_description` field.
+
+### Consequences
+
+**Positive:**
+- Extension details view: 3+ downloads → 1 companion fetch; warm cache →
+  2 digest probes, zero downloads.
+- Net command surface: −1 top-level command vs v1 (describe stays, desc
+  dies, nothing new).
+- Standard repo layout publishes docs with zero config.
+
+**Negative:**
+- `grim publish` behavior change: conventional files now auto-publish a
+  companion (opt-out documented, CHANGELOG entry; pre-1.0).
+- `fetch` report becomes tri-shaped (content / description-bundle /
+  digest-only) — each mode's JSON documented in `json-interface.md`.
+- `publish.toml` JSON Schema changes (`grim schema --kind publish`).
+
+**Risks:**
+- Unintended fan-out: a multi-package manifest with a root README stamps
+  the same docs on every repo. Mitigation: per-entry override/opt-out is
+  first-class; dry-run preview lists planned companion pushes.
+- Fetch flag interplay errors (`--out` without `--description`, `--vendor`
+  with `--description`) must fail as usage errors (64) with clear wording.
+
+## Implementation Plan
+
+1. [ ] Fetch core: typed fetched-kind (replace `kind: ArtifactKind` +
+   `is_description` bool placeholder in `FetchedArtifact`) — independent
+   refactor
+2. [ ] `[description]` parsing (`PublishManifest`, `PublishEntrySpec` —
+   untagged bool|table), conventional probe, in-batch companion publish,
+   delete `src/command/desc.rs` + report + CLI wiring
+3. [ ] `fetch --description` / `--digest-only` / `--out`, describe
+   `has_description` field, MCP parity
+4. [ ] Docs (`publishing.md`, `commands.md`, `json-interface.md`,
+   `artifacts.md`), catalog skill drift review, acceptance tests
+5. [ ] Extension handover: `.claude/artifacts/handover_vscode_description_api.md`
+
+## Links
+
+- [adr_oci_empty_config_compat.md](./adr_oci_empty_config_compat.md) — no
+  custom artifactType on the wire
+- [adr_fetch_service_extraction.md](./adr_fetch_service_extraction.md) —
+  the shared fetch core these flags extend
+- [adr_repository_annotation.md](./adr_repository_annotation.md) —
+  precedent: metadata lives on manifest annotations
+- [handover_vscode_description_api.md](./handover_vscode_description_api.md)
+  — consumer migration guide

--- a/.claude/artifacts/handover_vscode_description_api.md
+++ b/.claude/artifacts/handover_vscode_description_api.md
@@ -1,0 +1,140 @@
+# Handover: description companion v2 — VS Code extension migration
+
+**Audience:** grimoire-vscode maintainers (parallel adoption while grim
+lands the rework).
+**Source of truth:** [`adr_description_companion.md`](./adr_description_companion.md).
+**Status:** contract accepted 2026-07-12; JSON shapes below are frozen at
+the contract level (field names/semantics), exact wording of docs pending
+`json-interface.md` update. grim work happens on `feat/vscode-extension-api`
+(PR #33 — v1 surface there is being reworked in place; do NOT build
+against v1's `grim desc publish` or the raw `__grimoire` ref contract).
+
+## TL;DR
+
+- Stop building `repo:__grimoire` refs. The tag becomes grim-internal.
+- One call replaces the companion probe + per-file follow-ups:
+  `grim fetch <ref> --description` returns **all files inline**.
+- New cache primitive: `grim fetch <ref> [--description] --digest-only`
+  → `{ref, digest}`, no download. Cache everything by digest.
+- `grim describe` gains `has_description: bool` — no more blind probe on
+  miss. (Not `description` — that key already carries the description-text
+  annotation and stays unchanged.)
+- README is no longer guaranteed present in a companion (all members
+  optional). Extension already null-safe — keep it that way.
+- `grim desc publish` is removed (write moves into `grim publish`
+  `[description]`). Extension never called it — no action.
+
+## Call-site migration map
+
+References = current extension code (as explored 2026-07-12).
+
+| Extension site | Today | After |
+|---|---|---|
+| `grim.ts` `DESC_TAG`, `descRef()` (:287-294) | builds `repo:__grimoire` | **delete**; pass `--description` flag via `fetchArgs` |
+| `details.ts:462` companion fetch | `fetch <repo:__grimoire>` then reuse | `fetch <repo> --description` → one report with ALL files inline |
+| `details.ts:408-432` `fetchLogo` (`fetch --path <logo>`) | separate call, base64 | read `files[]` entry from the `--description` report (base64 already inline) |
+| `details.ts:479-481` CHANGELOG (`fetch --path CHANGELOG.md`) | separate call | same — read from `files[]` |
+| `details.ts:436-450` in-tree readme (`fetch --path <name>/README.md`) | fallback channel | unchanged; companion still wins when present (`details.ts:488` precedence stays correct) |
+| `details.ts:404` / `pickVersion.ts:25` `describe` | metadata + tags | unchanged; additionally read new `has_description: bool` to skip the companion call when `false` |
+| companion miss handling | swallow not-found error | mostly obsolete — gate on `describe.has_description`; keep the null fallback for older grim |
+
+## New JSON shapes
+
+### `grim fetch <ref> --description --format json`
+
+```jsonc
+{
+  "ref": "ghcr.io/acme/thing:__grimoire",   // resolved companion ref
+  "digest": "sha256:…",                      // companion manifest digest → cache key
+  "kind": "desc",
+  "files": [
+    { "path": "README.md",    "size": 812,  "content": "…" },
+    { "path": "logo.svg",     "size": 4096, "content": "…", "encoding": "base64" },
+    { "path": "CHANGELOG.md", "size": 301,  "content": "…" }
+  ]
+}
+```
+
+- `encoding` present only for binary members (`"base64"`), same convention
+  as today's fetch `--path` binary handling. Omit-empty shape (fetch is
+  the documented exemption to always-present-null).
+- Well-known member names: `README.md`, `logo.png` | `logo.svg`,
+  `CHANGELOG.md`. Extra files possible (README-referenced assets) — ignore
+  unknown paths.
+- **Every member optional.** Companion may exist with only a logo.
+- Bounded by grim's 8 MiB layer gate; no truncation inside the report.
+- Missing companion: standard error envelope, exit 79 (not-found).
+
+### `grim fetch <ref> [--description] --digest-only --format json`
+
+```jsonc
+{ "ref": "ghcr.io/acme/thing:1.2.0", "digest": "sha256:…" }
+```
+
+- No layer download — cheap enough to fire on every details-view open.
+- Without `--description`: the artifact's manifest digest. One digest
+  covers annotations AND content (they live in the same manifest), so it
+  invalidates both your `describe` cache and your `fetch` cache.
+- With `--description`: the companion tag's manifest digest.
+
+### `grim describe <ref>` — additive field
+
+```jsonc
+{ …existing fields…, "has_description": true }
+```
+
+The existing `description` key (description-text annotation, rendered in
+the details header) is untouched — the presence flag is a separate
+`has_description` key.
+
+Always present (describe is the always-present-null contract). Treat
+missing key as "older grim → unknown, fall back to probe" — same
+tolerance pattern as `registries[].authenticated`.
+
+## Recommended caching flow
+
+```
+open details(ref):
+  d1 = fetch ref --digest-only                     # 1 HEAD
+  if cache[d1] miss:
+      describe ref  +  fetch ref                   # metadata + content
+      cache[d1] = …
+  if describe.has_description:                      # or cached value
+      d2 = fetch ref --description --digest-only   # 1 HEAD
+      if cache[d2] miss:
+          fetch ref --description                  # ONE call: readme+logo+changelog
+          cache[d2] = …
+```
+
+Warm path: 2 digest probes, 0 downloads (today: 3+ full calls). Digests
+are content addresses — cache never stales silently; evict LRU.
+
+## Unchanged surfaces (rely on them)
+
+- `describe` metadata fields, tags[], merge precedence you implement today.
+- `search`, `status`, `context` (incl. `registries[].authenticated`).
+- Error envelope `{error:{code,exit,message,reason?}}`; `reason:
+  "stale-lock"` semantics. (A broader typed reason taxonomy is planned
+  grim-side — additive, kebab-case, unknown values must stay tolerated.
+  Your current handling is already correct.)
+- In-tree README channel (`fetch --path <name>/README.md`) as fallback.
+
+## Sequencing / feature detection
+
+1. grim lands the rework on `feat/vscode-extension-api` (reworks v1 in
+   place; ships in the next 0.x release after merge).
+2. Extension can prepare now behind detection:
+   - `describe.has_description` key present → new grim; use
+     `--description` and `--digest-only`.
+   - Key absent → old grim; keep current `descRef()` probe path until the
+     minimum supported grim version includes v2, then delete it.
+3. `grim fetch <repo>:__grimoire` keeps resolving (exact-tag resolution is
+   not removed) — your current code won't break during the transition; it
+   just stops being the documented contract.
+
+## Open items (grim-side, tracked in ADR implementation plan)
+
+- Exact `json-interface.md` wording for the tri-shaped fetch report.
+- MCP `grim_fetch` arg names (`description`, `digest_only`) — parity with
+  CLI, relevant only if the extension ever moves to the MCP server.
+- `ErrorReason` enum refactor (wire-compatible, no extension action).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Carry keywords and summary through the package index so index-backed search matches them *(index)*
+- Repository description companion: `publish.toml` `[description]` table (`readme`/`logo`/`changelog`/`include`), with a conventional-file auto-probe (`README.md`, `CHANGELOG.md`, `logo.*`) and per-entry override/opt-out *(publish)*
+- `grim fetch --description` (the description companion, every file inline; `--out` unpacks it to disk) and `--digest-only` (a resolve-only cache probe, composes with `--description`) *(fetch)*
+- `has_description` field on `grim describe`, derived from the tag listing at zero extra network cost *(describe)*
+
+### Changed
+
+- `grim publish` auto-publishes a description companion when conventional files (`README.md`, `CHANGELOG.md`, `logo.*`) are present in the manifest directory; opt out with the manifest-wide `publish = false` or a per-entry `description = false` *(publish)* **BREAKING**
+- A missing artifact or description companion on `grim fetch` / `grim describe` now classifies as not-found (exit 79), matching the documented contract *(fetch)*
+
+### Removed
+
+- `grim desc` (introduced this cycle, never released) — description companions now publish through `grim publish` and read through `grim fetch --description` *(desc)*
 
 ## [0.8.4] - 2026-07-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Carry keywords and summary through the package index so index-backed search matches them *(index)*
+
 ## [0.8.4] - 2026-07-07
 
 ### Added

--- a/catalog/skills/grim-authoring/SKILL.md
+++ b/catalog/skills/grim-authoring/SKILL.md
@@ -44,23 +44,26 @@ servers (always `--kind mcp`, or the `.toml` is treated as a bundle).
 
 ## The Metadata-Location Asymmetry
 
-Where catalog metadata (`summary`, `keywords`, `repository`, `deprecated`)
-is authored differs by kind. This is the #1 authoring confusion — misplaced
-keys are not errors, they just silently never reach the catalog:
+Where catalog metadata (`summary`, `keywords`, `repository`, `deprecated`,
+`replaced-by`) is authored differs by kind. This is the #1 authoring
+confusion — misplaced keys are not errors, they just silently never reach
+the catalog:
 
-| Kind | `summary` / `keywords` / `repository` / `deprecated` live… |
+| Kind | `summary` / `keywords` / `repository` / `deprecated` / `replaced-by` live… |
 |---|---|
 | Skill | inside the `metadata:` map of `SKILL.md` frontmatter |
 | Agent | inside the `metadata:` map of the agent frontmatter |
 | Rule | at the **top level** of the rule frontmatter (not in `metadata`) |
-| MCP server | as **top-level TOML keys**, above the `[server]` table |
+| MCP server | as **top-level TOML keys**, above the `[server]` table (`replaced-by` not read for MCP) |
 | Bundle | as **top-level TOML keys**, above the member tables |
 
 In every kind, `keywords` is one comma-separated string and `repository`
 must be an `https://` URL (anything else fails the release with 65). The
 `deprecated` notice (grim 0.6.x) obeys the same per-kind location; an
 empty or whitespace-only value means *not* deprecated and emits no
-annotation — detail in [Publishing][publishing].
+annotation. `replaced-by` names the successor artifact, authored
+independently of `deprecated`; its value must parse as a reference or the
+release fails with 65 — detail in [Publishing][publishing].
 
 ## Companion: Content Craft
 

--- a/catalog/skills/grim-authoring/references/agent-spec.md
+++ b/catalog/skills/grim-authoring/references/agent-spec.md
@@ -39,7 +39,7 @@ every client.
 | `description` | yes | When a client should delegate to this agent |
 | `model` | no | Passed through verbatim — **no alias translation** between clients |
 | `tools` | no | Comma-separated allowlist, projected per client (string vs. list) |
-| `metadata` | no | Catalog keys (`summary`, `keywords`, `repository`, `deprecated`) **plus** vendor keys — agent catalog metadata lives inside `metadata`, like a skill |
+| `metadata` | no | Catalog keys (`summary`, `keywords`, `repository`, `deprecated`, `replaced-by`) **plus** vendor keys — agent catalog metadata lives inside `metadata`, like a skill |
 
 ## Vendor Overrides
 

--- a/catalog/skills/grim-authoring/references/bundle-spec.md
+++ b/catalog/skills/grim-authoring/references/bundle-spec.md
@@ -28,6 +28,7 @@ tables — not in any nested map:
 | `description` | Overrides the automatic `grimoire bundle of N members` |
 | `repository` | `https://` source URL; anything else fails release (exit 65) |
 | `deprecated` | Deprecation notice; non-empty marks the bundle deprecated (flagged in search/TUI, warned on `add`) |
+| `replaced-by` | Successor reference (independent of `deprecated`); surfaced in search / `grim describe`. Must parse as a reference or the release fails (exit 65) |
 
 The bundle source parser is **strict** (`deny_unknown_fields`): any key
 outside this set and the three member tables is a hard parse error.

--- a/catalog/skills/grim-authoring/references/rule-spec.md
+++ b/catalog/skills/grim-authoring/references/rule-spec.md
@@ -32,6 +32,7 @@ round-trip.
 | `keywords` | string | **Top-level** — comma-separated tags (a YAML list is tolerated and comma-joined, but write the string form: it is the only shape valid in every kind) |
 | `repository` | string | **Top-level** — `https://` source URL, hard-gated at release |
 | `deprecated` | string | **Top-level** — deprecation notice; non-empty marks the rule deprecated (flagged in search/TUI, warned on `add`) |
+| `replaced-by` | string | **Top-level** — successor reference (independent of `deprecated`); surfaced in search / `grim describe`. Must parse as a reference or the release fails (exit 65) |
 | `metadata` | string→string map | Vendor extensions only (e.g. `copilot.exclude-agent`) |
 
 ## The Asymmetry

--- a/catalog/skills/grim-authoring/references/skill-spec.md
+++ b/catalog/skills/grim-authoring/references/skill-spec.md
@@ -49,6 +49,7 @@ rules and bundles, where these keys are top-level):
 | `metadata.keywords` | One comma-separated string — `review,quality`, never a YAML list |
 | `metadata.repository` | `https://` URL only; `git@…` or `http://` fails the release (exit 65) |
 | `metadata.deprecated` | Deprecation notice; non-empty marks the skill deprecated (flagged in search/TUI, warned on `add`). Empty ⇒ not deprecated |
+| `metadata.replaced-by` | Successor reference (independent of `deprecated`); surfaced in search / `grim describe`. Must parse as a reference or the release fails (exit 65) |
 
 Full annotation mapping: [catalog metadata][pub-metadata] and
 [annotations][annotations].

--- a/catalog/skills/grim-usage/SKILL.md
+++ b/catalog/skills/grim-usage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: grim-usage
-description: Drive the grim CLI — the OCI package manager for AI skills, rules, agents, and bundles. Use when installing, updating, searching, or publishing AI-config artifacts with grim; when composing grim init, config, add, lock, install, update, status, context, fetch, search, tui, mcp, build, release, publish, login, or logout commands; when configuring settings, multiple registries, or qualified alias/repo references; or when resolving registries, project vs global scope, client targets, or offline mode.
+description: Drive the grim CLI — the OCI package manager for AI skills, rules, agents, and bundles. Use when installing, updating, searching, or publishing AI-config artifacts with grim; when composing grim init, config, add, lock, install, update, status, context, fetch, describe, search, tui, mcp, build, release, publish, login, or logout commands; when configuring settings, multiple registries, or qualified alias/repo references; or when resolving registries, project vs global scope, client targets, or offline mode.
 license: Apache-2.0
 compatibility: grim>=0.6
 metadata:
@@ -47,6 +47,7 @@ full reference is `--help` plus the docs site linked below.
 | `grim status` | Report each declared artifact's state | [consume](references/consume.md) |
 | `grim context` | Report the resolved scope, paths, clients, registries | [consume](references/consume.md) |
 | `grim fetch` | Print an artifact's content without installing | [consume](references/consume.md) |
+| `grim describe` | Report an artifact's metadata (kind, annotations, tags) without downloading content | [consume](references/consume.md) |
 | `grim remove` / `uninstall` | Undeclare vs full inverse of install | [consume](references/consume.md) |
 | `grim search` / `tui` | Browse your declared registries' catalogs | [registries](references/registries.md) |
 | `grim mcp` | Run a local STDIO MCP server for AI agent integration | [registries](references/registries.md) |

--- a/catalog/skills/grim-usage/references/consume.md
+++ b/catalog/skills/grim-usage/references/consume.md
@@ -195,14 +195,21 @@ Two read-only companions:
   content without installing (use != install). Plain output is the raw
   payload (pipe-able: `grim fetch skills/x > SKILL.md`); `--format json`
   adds the digest, kind, and a `files` listing. A binary `--path` file
-  (e.g. `logo.png`) round-trips through a redirect. Confirm flags with
-  `grim fetch --help`.
+  (e.g. `logo.png`) round-trips through a redirect. `--description`
+  retargets the fetch to the repository's description companion (README,
+  logo, CHANGELOG) instead of the artifact — JSON inlines every member,
+  plain requires `--out <dir>` to unpack the tree (no single payload to
+  print). `--digest-only` resolves a digest without downloading anything —
+  a cheap cache probe — and composes with `--description` to probe the
+  companion tag instead. Confirm flags with `grim fetch --help`.
 - `grim describe <ref>` reports an artifact's manifest-level metadata —
   kind, curated annotations, tags, and the verbatim annotation map —
   *without* downloading its content, so it is the cheap way to inspect a
-  package or discover its versions. `--format json` is a single object;
-  plain output is a flat key/value table. Confirm with `grim describe
-  --help`.
+  package or discover its versions. It also reports `has_description` —
+  whether the repository has a description companion — derived from the
+  tag listing it already fetches, at zero extra network cost. `--format
+  json` is a single object; plain output is a flat key/value table.
+  Confirm with `grim describe --help`.
 
 ## Removing
 

--- a/catalog/skills/grim-usage/references/consume.md
+++ b/catalog/skills/grim-usage/references/consume.md
@@ -194,8 +194,15 @@ Two read-only companions:
 - `grim fetch <ref> [--vendor …] [--path …]` prints an artifact's
   content without installing (use != install). Plain output is the raw
   payload (pipe-able: `grim fetch skills/x > SKILL.md`); `--format json`
-  adds the digest, kind, and a `files` listing. Confirm flags with
+  adds the digest, kind, and a `files` listing. A binary `--path` file
+  (e.g. `logo.png`) round-trips through a redirect. Confirm flags with
   `grim fetch --help`.
+- `grim describe <ref>` reports an artifact's manifest-level metadata —
+  kind, curated annotations, tags, and the verbatim annotation map —
+  *without* downloading its content, so it is the cheap way to inspect a
+  package or discover its versions. `--format json` is a single object;
+  plain output is a flat key/value table. Confirm with `grim describe
+  --help`.
 
 ## Removing
 

--- a/catalog/skills/grim-usage/references/publish.md
+++ b/catalog/skills/grim-usage/references/publish.md
@@ -264,9 +264,12 @@ TUI: `summary`, `keywords`, `description`, `repository`. A fifth field,
 `deprecated` (grim 0.6.x), retires a package *without* unpublishing it —
 a non-empty notice keeps it resolving and installing while grim flags it
 in `grim search`, the TUI, and on `grim add`; an empty or whitespace
-value means not deprecated. You author them all in the source file
-itself, so a release always publishes what the file says. Two invariants
-hold for every kind:
+value means not deprecated. A sixth, `replaced-by`, names the successor
+artifact (authored independently of `deprecated`) — surfaced as
+`replaced_by` in `grim search` / `grim describe --format json`; the value
+must parse as a reference or the release fails with exit 65. You author
+them all in the source file itself, so a release always publishes what the
+file says. Two invariants hold for every kind:
 
 - `keywords` is a single comma-separated **string** (`rust,lint`), never
   a YAML/TOML list — an OCI annotation value is a string.

--- a/catalog/skills/grim-usage/references/publish.md
+++ b/catalog/skills/grim-usage/references/publish.md
@@ -8,7 +8,9 @@ Contents: [Build, Then Release](#build-then-release) ·
 [Cascade Tags](#cascade-tags) · [Immutability](#immutability) ·
 [Scripted Publishing](#scripted-publishing) ·
 [Announcing to the Index](#announce) · [Bundles](#bundles) ·
-[Catalog Metadata](#catalog-metadata) · [Authentication](#authentication)
+[Catalog Metadata](#catalog-metadata) ·
+[Description Companion](#description-companion) ·
+[Authentication](#authentication)
 
 Flags shown here are grim 0.6.x; confirm with `grim <cmd> --help` before
 relying on one.
@@ -280,6 +282,52 @@ file says. Two invariants hold for every kind:
 `metadata` map; rule: top-level frontmatter; bundle: top-level TOML) —
 see [the per-kind examples][metadata].
 
+## Description Companion {#description-companion}
+
+The in-tree README convention ([artifacts.md][artifacts-readme]) only
+reaches tar-backed kinds — mcp and bundle publish a single JSON layer with
+no file tree. For a README/logo/CHANGELOG that reads back uniformly
+across **every** kind, `grim publish` can push a repository-level
+**description companion**: a small doc bundle stored at an internal tag in
+the same repository, read back via `grim fetch <ref> --description` (see
+[consume.md](consume.md#inspecting)) — the tag itself is never something
+you type.
+
+Author it in `publish.toml` with a top-level `[description]` table (paths
+relative to the manifest):
+
+```toml
+[description]
+readme    = "README.md"
+logo      = "assets/logo.png"
+changelog = "CHANGELOG.md"
+include   = ["docs/img/*.png"]   # extra README-referenced assets
+```
+
+- **Fan-out.** The top-level `[description]` publishes to **every**
+  entry's repository. Override one entry with its own
+  `[<kind>.<name>.description]` table (same schema), or opt it out with
+  `description = false`. A manifest-wide `publish = false` inside the
+  top-level table disables the companion for the whole run.
+- **Convention fallback.** With no `[description]` table at all, grim
+  probes the manifest directory for `README.md`, `CHANGELOG.md`, and
+  `assets/logo.png|svg` / `logo.png|svg`; any hit publishes a companion
+  automatically (opt out per entry with `description = false`). All
+  members are optional — an explicit table that resolves to zero files is
+  a data error (exit 65), but a conventional-probe miss is silent.
+- Companion pushes ride the same `grim publish` batch, after the entry's
+  own artifact push, and are idempotent — unchanged content republishes
+  to the same digest. `--dry-run` previews the planned companion pushes
+  alongside the artifact plan, and the `--format json` report carries a
+  `descriptions` section (`{"items": [...], "descriptions": {...}, ...}`)
+  beside the usual per-entry `items`.
+- There is no separate publish command for it — re-running `grim publish`
+  after a docs-only edit re-points the companion; the artifacts themselves
+  skip-existing as usual.
+
+Confirm the current schema with `grim schema --kind publish` and flags
+with `grim publish --help`.
+
 ## Git Provenance
 
 `build`, `release`, and `publish` take an opt-in `--git` flag that stamps the
@@ -343,3 +391,4 @@ With no positional registry, `login`/`logout` resolve `--registry`, then
 [editor-schema]: https://grimoire.rs/configuration.html#editor-schema
 [auth]: https://grimoire.rs/authentication.html
 [commands]: https://grimoire.rs/commands.html#build
+[artifacts-readme]: https://grimoire.rs/artifacts.html#well-known-assets

--- a/docs/src/artifacts.md
+++ b/docs/src/artifacts.md
@@ -142,6 +142,25 @@ frontmatter (`user-invocable: true`, `effort: high`) in the file Claude
 Code receives; other clients never see them. The projection rules live in
 [Vendor-Specific Metadata](./vendor-metadata.md#projection-semantics).
 
+### Well-known assets — README, logo {#well-known-assets}
+
+Because a skill packs its **whole** directory tree verbatim, two conventional
+files placed beside `SKILL.md` ride along at no extra cost:
+
+- `README.md` — a human-facing readme for the artifact.
+- `logo.png` / `logo.svg` — an icon for a catalog or gallery UI.
+
+They are ordinary tree files, so they need no frontmatter and no special
+handling: they appear in the [`grim fetch`](./commands.md#fetch) `files[]`
+listing and can be pulled individually with `--path` (a binary `logo.png`
+comes back base64-encoded, decoding to the exact bytes in plain mode). This
+is a **convention, not a schema** — grim reads no meaning from these names;
+they are simply the agreed spot a tool looks for a readme or an icon.
+
+A rule follows the same convention inside its [sibling support
+directory](#rules) (`architecture-guide/README.md`,
+`architecture-guide/logo.png`), which packs into the same layer tree.
+
 ## Rules {#rules}
 
 A rule is a single Markdown file. Frontmatter is entirely optional — a

--- a/docs/src/artifacts.md
+++ b/docs/src/artifacts.md
@@ -161,6 +161,22 @@ A rule follows the same convention inside its [sibling support
 directory](#rules) (`architecture-guide/README.md`,
 `architecture-guide/logo.png`), which packs into the same layer tree.
 
+An [agent](#agents) — a single `.md` file — carries the same well-known
+files from a sibling directory sharing its stem (`agents/<name>/README.md`,
+`agents/<name>/logo.png`, `agents/<name>/logo.svg`). Unlike a rule's support
+directory, an agent packs **only** those allowlisted files, never an arbitrary
+tree: the agent's identity stays the standalone `<name>.md`, and the companions
+ride the layer purely so a catalog UI can show them. They land under
+`<name>/…` in the layer, so the retrieval path is identical for every tree-backed
+kind — `grim fetch <ref> --path <name>/README.md`. The companions are not
+installed to a client (an agent installs as its lone `.md`); they exist for
+`grim fetch`/catalog consumers.
+
+[MCP servers](#mcp-servers) and [bundles](#bundles) have no file tree — their
+layer is a single JSON document — so they carry no README/logo companion. A
+catalog UI shows their `description`/`summary` (from
+[`grim describe`](./commands.md#describe)) instead.
+
 ## Rules {#rules}
 
 A rule is a single Markdown file. Frontmatter is entirely optional — a
@@ -253,6 +269,12 @@ vendor key lifts to the same native field as a common field (`model`,
 `tools`), the vendor key silently wins for that client — the documented
 override escape hatch
 ([override precedence](./agents.md#override-precedence)).
+
+An agent may ship a `README.md` and a `logo.png`/`logo.svg` from a sibling
+directory sharing its stem (`agents/<name>/`) — the
+[well-known assets](#well-known-assets) convention. Only those allowlisted
+files ride the layer; every other file in that directory is ignored, so the
+installed agent stays the single `<name>.md`.
 
 ### Example — minimal agent {#agent-example-minimal}
 

--- a/docs/src/artifacts.md
+++ b/docs/src/artifacts.md
@@ -172,10 +172,14 @@ kind — `grim fetch <ref> --path <name>/README.md`. The companions are not
 installed to a client (an agent installs as its lone `.md`); they exist for
 `grim fetch`/catalog consumers.
 
-[MCP servers](#mcp-servers) and [bundles](#bundles) have no file tree — their
-layer is a single JSON document — so they carry no README/logo companion. A
-catalog UI shows their `description`/`summary` (from
-[`grim describe`](./commands.md#describe)) instead.
+[MCP servers](#mcp-servers) and [bundles](#bundles) have no file tree of their
+own — their layer is a single JSON document — so they carry no *in-tree* README.
+For a README that works uniformly across **every** kind (including mcp and
+bundle), publish a [repository description companion](./publishing.md#description-companion):
+declare a `[description]` table in `publish.toml` (or let grim probe the
+conventional `README.md` / `CHANGELOG.md` / `logo.*` files) and it rides
+[`grim publish`](./commands.md#publish); read it back with
+[`grim fetch <repo> --description`](./commands.md#fetch-description).
 
 ## Rules {#rules}
 

--- a/docs/src/commands.md
+++ b/docs/src/commands.md
@@ -487,7 +487,9 @@ terminal that column is truncated to fit the width; piped output and
 `--format json` keep the full description. The JSON output also carries a
 `repository` field — the artifact's authored
 [repository URL](./publishing.md#metadata-repository), or `null` when the
-artifact has none.
+artifact has none — and a `replaced_by` field — the authored
+[successor reference](./publishing.md#metadata-replaced-by), or `null` when
+none. Neither is shown in the plain table.
 
 A [deprecated](./publishing.md#metadata-deprecated) entry is **hidden by
 default** — unless it is installed in the active scope (directly or via a
@@ -510,21 +512,28 @@ grim search --refresh --registry ghcr.io/acme
 install**: nothing is materialized, no state is touched. It is the CLI
 port of the MCP [`grim_fetch` tool](#mcp): canonical (as-authored) content
 by default, a `--vendor <claude|opencode|copilot>` projection, or one
-`--path <tree-path>` support file (UTF-8 text only).
+`--path <tree-path>` support file.
 
-Plain output is the **raw content payload** — exact bytes, no table, no
-added trailing newline — so it pipes:
+A `--path` file is UTF-8 text by default. A **binary** support file (e.g. a
+`logo.png`) that fits within the size limit is returned base64-encoded — the
+JSON report gains an `encoding: "base64"` field, and plain output **decodes
+it back to the raw bytes**, so a redirect round-trips byte-identical:
 
 ```sh
 grim fetch skills/code-review > SKILL.md
 grim fetch skills/code-review --path code-review/references/checklist.md
+grim fetch skills/code-review --path code-review/logo.png > logo.png   # binary, byte-identical
 grim fetch skills/code-review --format json | jq '.files[].path'
 ```
 
+Plain output is the **raw content payload** — exact bytes, no table, no
+added trailing newline — so it pipes.
+
 `--format json` emits the full fetch report: `{ref, digest, kind, name,
-vendor, path?, content, truncated?, files?, pointer?, warnings?}` (the
-MCP payload shape — empty/default fields omitted). Warnings print to
-stderr, keeping stdout a pure payload.
+vendor, path?, content, encoding?, truncated?, files?, pointer?, warnings?}`
+(the MCP payload shape — empty/default fields omitted; `encoding` is present
+only for a base64 binary `--path` file). Warnings print to stderr, keeping
+stdout a pure payload.
 
 Unlike the MCP tool — which truncates documents at 256 KiB for tool-result
 budgets — the CLI **never truncates** a printed payload. Two ceilings guard
@@ -534,6 +543,45 @@ declared layer size is checked against the 8 MiB limit *before* download
 declared size then bounds the *actual* streamed bytes — a registry that
 serves more than it declared aborts mid-transfer into a data error (exit
 65) rather than growing an unbounded body in memory.
+
+## grim describe {#describe}
+
+`grim describe <ref>` reports an artifact's **manifest-level metadata** —
+its kind, curated annotations, and tags — **without downloading its
+content**. Where [`grim fetch`](#fetch) pulls the layer to print the
+document, `describe` only resolves the reference, lists the repository's
+tags, and reads the manifest annotations, so it is a cheap way to inspect an
+artifact (or discover its available versions) before fetching or installing.
+It is the CLI port of the MCP [`grim_describe` tool](#mcp) and takes no flags
+beyond the globals.
+
+`--format json` emits a single object with every field always present
+(explicit `null` when absent; `keywords`/`tags` are `[]` when none, and
+`annotations` is the verbatim manifest annotation map):
+
+```
+{ref, digest, kind, name, title, description, summary, version, license,
+ repository, revision, created, keywords, deprecated, replaced_by, tags,
+ annotations}
+```
+
+`kind` is `null` for a foreign / non-Grimoire manifest (describe never
+hard-errors on one). The curated fields follow [`grim search`](#search)
+semantics: `repository` is kept only when the source annotation is an
+`https://` URL, `deprecated` is the deprecation notice or `null`, and
+`replaced_by` is the [successor reference](./publishing.md#metadata-replaced-by)
+or `null`. Plain output is a flat key/value table (like
+[`grim context`](#context)) with `keywords` and `tags` comma-joined.
+
+```sh
+grim describe skills/code-review
+grim describe ghcr.io/acme/skills/code-review:1.2.0 --format json | jq .tags
+```
+
+Errors follow the fetch taxonomy: a missing repository is a not-found
+failure (parity with `grim fetch`), an auth failure exits 80, an offline run
+that cannot reach the registry exits 81, and an unreachable registry exits
+69.
 
 ## grim tui {#tui}
 
@@ -866,13 +914,15 @@ down when the client closes stdin (EOF).
 |------|-------------|------|
 | `grim_search` | Browse/search the resolved scope's registries (no registry override — the configured set is the boundary). Args: `query?`, `refresh?`, scope. Same shape as `grim search --format json` (not byte-identical — see [MCP parity][json-mcp-parity]). | always |
 | `grim_status` | Install status of every declared artifact in the requested scope. Args: scope. Same shape as `grim status --format json` (not byte-identical — see [MCP parity][json-mcp-parity]). | always |
-| `grim_fetch` | Return an artifact's content in the tool result — no install. Canonical bytes by default; `vendor` (`claude`/`opencode`/`copilot`) returns that client's projection; `path` fetches one support file; a `files` listing is always included. Content caps at 256 KiB (truncated content carries a marker); layers over 8 MiB are refused before download, and a registry that streams more bytes than its declared layer size aborts mid-transfer into a data error rather than buffering an unbounded body. Args: `ref`, `vendor?`, `path?`, scope. | always |
+| `grim_fetch` | Return an artifact's content in the tool result — no install. Canonical bytes by default; `vendor` (`claude`/`opencode`/`copilot`) returns that client's projection; `path` fetches one support file (base64 with `encoding: "base64"` for a binary file); a `files` listing is always included. Content caps at 256 KiB (truncated content carries a marker); layers over 8 MiB are refused before download, and a registry that streams more bytes than its declared layer size aborts mid-transfer into a data error rather than buffering an unbounded body. Args: `ref`, `vendor?`, `path?`, scope. | always |
+| `grim_describe` | Report an artifact's manifest-level metadata — kind, curated annotations, tags, and the verbatim annotation map — without downloading its content. Same shape as `grim describe --format json`. Args: `ref`, scope. | always |
 | `grim_render` | Write an artifact's vendor-native files into an arbitrary `dest_dir` (created if absent) — no install state, no client-config edits. Skill → `<dest_dir>/<name>/`, rule/agent → `<dest_dir>/<name>.md`. Args: `ref`, `vendor`, `dest_dir`, scope. | `--allow-writes` |
 
 The scope arguments on each tool are `global` (boolean), `config` (explicit
 `grimoire.toml` path), and `workspace` (directory to start the config
-walk-up from). `grim_fetch` and `grim_render` use them only to decide which
-registries resolve the reference — neither touches install state.
+walk-up from). `grim_fetch`, `grim_describe`, and `grim_render` use them
+only to decide which registries resolve the reference — none touches install
+state.
 
 **Registering with Claude Code** — add to `.mcp.json` in the project root
 (or register globally via `claude mcp add`):

--- a/docs/src/commands.md
+++ b/docs/src/commands.md
@@ -412,10 +412,19 @@ grim context --format json | jq .clients
 The JSON document is a single object: `{version, scope, workspace,
 config_path, config_exists, lock_path, lock_exists, state_path, grim_home,
 offline, offline_source, clients, registries, default_registry}`.
-`registries` entries are `{alias, url, kind, default}` with `kind` either
-`registry` or `index`. `clients` carries **names only** — the vendor
-on-disk layout is not a contract; script installed locations via
-[`grim status --format json`](#status) `outputs` instead.
+`registries` entries are `{alias, url, kind, default, authenticated}` with
+`kind` either `registry` or `index`. `authenticated` is a boolean: `true`
+when a credential for this registry's **host** is present in the
+docker-compatible credential store (`~/.docker/config.json`, or
+`$DOCKER_CONFIG/config.json`) — an `auths` or `credHelpers` entry for the
+host. It is a file-only probe that never invokes a credential helper, so a
+global `credsStore` with no matching per-host entry is **not** detected as
+authenticated, and a missing, unreadable, or malformed config reports
+`false` for every registry rather than failing the command. The host is the
+url with any scheme and namespace path stripped, matching the credential
+grim uses when pulling from that registry. `clients` carries **names
+only** — the vendor on-disk layout is not a contract; script installed
+locations via [`grim status --format json`](#status) `outputs` instead.
 
 Scope follows the usual rules: project walk-up by default, `--global` for
 the global scope, `--config <path>` for an explicit file. Outside a

--- a/docs/src/commands.md
+++ b/docs/src/commands.md
@@ -521,7 +521,11 @@ grim search --refresh --registry ghcr.io/acme
 install**: nothing is materialized, no state is touched. It is the CLI
 port of the MCP [`grim_fetch` tool](#mcp): canonical (as-authored) content
 by default, a `--vendor <claude|opencode|copilot>` projection, or one
-`--path <tree-path>` support file.
+`--path <tree-path>` support file. Two more flags switch the report to a
+different shape entirely instead of fetching the artifact:
+[`--description`](#fetch-description) fetches the repository's description
+companion, and [`--digest-only`](#fetch-digest-only) resolves a digest
+without downloading anything.
 
 A `--path` file is UTF-8 text by default. A **binary** support file (e.g. a
 `logo.png`) that fits within the size limit is returned base64-encoded — the
@@ -551,7 +555,61 @@ declared layer size is checked against the 8 MiB limit *before* download
 (a cheap reject for an honestly-oversized layer, exit 65), and that same
 declared size then bounds the *actual* streamed bytes — a registry that
 serves more than it declared aborts mid-transfer into a data error (exit
-65) rather than growing an unbounded body in memory.
+65) rather than growing an unbounded body in memory. A missing repository
+or tag — the artifact itself, or (with `--description`) its companion —
+is a not-found failure (exit 79); an offline run against an uncached
+reference exits 81 instead, since the reference may exist and only the
+network to confirm it is unreachable.
+
+### Description companion (--description) {#fetch-description}
+
+`--description` retargets the reference to the repository's [description
+companion](./publishing.md#description-companion) — the reserved
+`__grimoire` tag is a grim-internal implementation detail; the flag is
+the documented way to reach it, so nothing outside grim needs to type or
+know the tag. `--format json` returns every packed file inline in one
+call instead of the single artifact document:
+
+```sh
+grim fetch ghcr.io/acme/mcp/postgres --description --format json | jq '.files[].path'
+grim fetch ghcr.io/acme/mcp/postgres --description --out ./docs   # unpack the tree to disk
+```
+
+The JSON shape is `{ref, digest, kind: "desc", files: [{path, size,
+content, encoding?}], warnings?}` — every member inline (`encoding:
+"base64"` only for a binary member), bounded by the same 8 MiB layer gate
+as any fetch and never per-file truncated, so the whole companion —
+README, logo, changelog, and any README-referenced assets — comes back in
+one report. A multi-file bundle has no single payload to print, so plain
+mode requires `--out <dir>` to unpack the tree to disk instead; without
+`--out` (and no `--path`), plain mode is a usage error (exit 64).
+
+### Cache probe (--digest-only) {#fetch-digest-only}
+
+`--digest-only` resolves the reference to a digest and reports `{ref,
+digest, warnings?}` **without downloading** the manifest or any blob — a
+cheap HEAD-equivalent probe. It composes with `--description` to probe
+the companion tag instead of the artifact; either way the reported digest
+equals the corresponding full fetch's manifest digest, so a consumer
+caches on it directly and skips an unchanged download:
+
+```sh
+grim fetch skills/code-review --digest-only --format json
+grim fetch skills/code-review --description --digest-only --format json
+```
+
+`--digest-only` takes no `--vendor`, `--path`, or `--out` — a digest-only
+probe never downloads content to shape, so combining any of them is a
+usage error (exit 64). An offline run against an uncached reference exits
+81 rather than a misleading not-found.
+
+### Flag-combination errors {#fetch-usage-errors}
+
+| Combination | Result |
+|---|---|
+| `--out` without `--description` | usage error (exit 64) |
+| `--digest-only` with `--vendor`, `--path`, or `--out` | usage error (exit 64) |
+| `--description` in plain mode, without `--out` and without `--path` | usage error (exit 64) |
 
 ## grim describe {#describe}
 
@@ -569,14 +627,23 @@ beyond the globals.
 `annotations` is the verbatim manifest annotation map):
 
 ```
-{ref, digest, kind, name, title, description, summary, version, license,
- repository, revision, created, keywords, deprecated, replaced_by, tags,
- annotations}
+{ref, digest, kind, name, title, description, has_description, summary,
+ version, license, repository, revision, created, keywords, deprecated,
+ replaced_by, tags, annotations}
 ```
 
 `kind` is `null` for a foreign / non-Grimoire manifest (describe never
-hard-errors on one). The curated fields follow [`grim search`](#search)
-semantics: `repository` is kept only when the source annotation is an
+hard-errors on one). `has_description` is an always-present boolean —
+whether the repository carries a [description
+companion](./publishing.md#description-companion) — derived from the tag
+listing describe already fetches, at zero extra network cost, so a
+consumer can skip a blind probe before calling
+[`grim fetch <ref> --description`](#fetch-description). `tags[]` lists
+only user-facing tags — grim-internal companions such as `__grimoire` (see
+the
+[repository description companion](./publishing.md#description-companion)) are
+hidden. The
+curated fields follow [`grim search`](#search) semantics: `repository` is kept only when the source annotation is an
 `https://` URL, `deprecated` is the deprecation notice or `null`, and
 `replaced_by` is the [successor reference](./publishing.md#metadata-replaced-by)
 or `null`. Plain output is a flat key/value table (like
@@ -923,8 +990,8 @@ down when the client closes stdin (EOF).
 |------|-------------|------|
 | `grim_search` | Browse/search the resolved scope's registries (no registry override — the configured set is the boundary). Args: `query?`, `refresh?`, scope. Same shape as `grim search --format json` (not byte-identical — see [MCP parity][json-mcp-parity]). | always |
 | `grim_status` | Install status of every declared artifact in the requested scope. Args: scope. Same shape as `grim status --format json` (not byte-identical — see [MCP parity][json-mcp-parity]). | always |
-| `grim_fetch` | Return an artifact's content in the tool result — no install. Canonical bytes by default; `vendor` (`claude`/`opencode`/`copilot`) returns that client's projection; `path` fetches one support file (base64 with `encoding: "base64"` for a binary file); a `files` listing is always included. Content caps at 256 KiB (truncated content carries a marker); layers over 8 MiB are refused before download, and a registry that streams more bytes than its declared layer size aborts mid-transfer into a data error rather than buffering an unbounded body. Args: `ref`, `vendor?`, `path?`, scope. | always |
-| `grim_describe` | Report an artifact's manifest-level metadata — kind, curated annotations, tags, and the verbatim annotation map — without downloading its content. Same shape as `grim describe --format json`. Args: `ref`, scope. | always |
+| `grim_fetch` | Return an artifact's content in the tool result — no install. Canonical bytes by default; `vendor` (`claude`/`opencode`/`copilot`) returns that client's projection; `path` fetches one support file (base64 with `encoding: "base64"` for a binary file); a `files` listing is always included. `description` fetches the repository's [description companion](./publishing.md#description-companion) instead (every member inline); `digest_only` resolves to `{ref, digest}` with no download and composes with `description` to probe the companion tag. Content caps at 256 KiB (truncated content carries a marker); layers over 8 MiB are refused before download, and a registry that streams more bytes than its declared layer size aborts mid-transfer into a data error rather than buffering an unbounded body. Args: `ref`, `vendor?`, `path?`, `description?`, `digest_only?`, scope. | always |
+| `grim_describe` | Report an artifact's manifest-level metadata — kind, curated annotations, tags, `has_description`, and the verbatim annotation map — without downloading its content. Same shape as `grim describe --format json`. Args: `ref`, scope. | always |
 | `grim_render` | Write an artifact's vendor-native files into an arbitrary `dest_dir` (created if absent) — no install state, no client-config edits. Skill → `<dest_dir>/<name>/`, rule/agent → `<dest_dir>/<name>.md`. Args: `ref`, `vendor`, `dest_dir`, scope. | `--allow-writes` |
 
 The scope arguments on each tool are `global` (boolean), `config` (explicit

--- a/docs/src/json-interface.md
+++ b/docs/src/json-interface.md
@@ -64,7 +64,7 @@ One row object per item inside `{"items": [...]}`:
 | `install` | `{kind, name, target, status}` | `status`: `installed`, `updated`, `unchanged`, `refused`, `skipped` |
 | `status` | `{kind, name, source, pinned, state, outputs}` — `pinned` null until locked; `outputs` is `[{client, path}]` (see [grim status][commands-status]) | `state`: `installed`, `stale`, `modified`, `missing`, `outdated` |
 | `update` | `{kind, name, old, new, action}` — `old` null for a first lock, `new` null for a pruned row | `action`: `updated`, `unchanged`, `removed`, `kept-modified` |
-| `search` | `{kind, repo, summary, description, version, latest_tag, repository, revision, created, deprecated, status}` — `kind` is `null` when the catalog row's manifest declares none; see [grim search][commands-search] | `status`: install badge (`installed`, `not-installed`, …) |
+| `search` | `{kind, repo, summary, description, version, latest_tag, repository, revision, created, deprecated, replaced_by, status}` — `kind` is `null` when the catalog row's manifest declares none; `replaced_by` is the successor reference or `null`; see [grim search][commands-search] | `status`: install badge (`installed`, `not-installed`, …) |
 | `config list` | `{key, value}` | — |
 | `config registry list` | `{alias, oci, index, default}` — both locator keys present, exactly one non-null | — |
 | `publish` | `{ref, kind, digest, tags, status}` + sibling envelope key `announce` (`{outcome, branch, url}` or null) — see [publish report][publishing-report] | `status`: `pushed`, `skipped`, `dry-run`, `failed` |
@@ -91,16 +91,19 @@ no kind at all, in which case `kind` is `null`.
 | `config set` / `unset` / `registry add` / `rm` / `use` | `{action, key, value, scope}` | `action`: `set`, `unset`, `registry-added`, `registry-removed`, `registry-default` |
 | `config registry show` | `{alias, oci, index, default}` — both locator keys present, exactly one non-null | — |
 | `context` | `{version, scope, workspace, config_path, config_exists, lock_path, lock_exists, state_path, grim_home, offline, offline_source, clients, registries, default_registry}` — see [grim context][commands-context] | `offline_source`: `flag`, `env`, or null |
-| `fetch` | `{ref, digest, kind, name, vendor, path?, content, truncated?, files?, pointer?, warnings?}` — see [grim fetch](#fetch) | — |
+| `describe` | `{ref, digest, kind, name, title, description, summary, version, license, repository, revision, created, keywords, deprecated, replaced_by, tags, annotations}` — every field always present; `kind` is `null` for a foreign manifest; `keywords`/`tags` are `[]` when none; `annotations` is the verbatim manifest map; see [grim describe][commands-describe] | — |
+| `fetch` | `{ref, digest, kind, name, vendor, path?, content, encoding?, truncated?, files?, pointer?, warnings?}` — see [grim fetch](#fetch) | — |
 
 ### The fetch exception {#fetch}
 
 `grim fetch` shares its JSON payload with the MCP `grim_fetch` tool, and
 that shape predates the [null policy](#null-policy): empty or default
-fields (`path`, `truncated`, `files`, `pointer`, `warnings`) are
-**omitted**, not null. Treat a missing key as its default. Its plain mode
-is the raw `content` payload (pipe-able, no report at all) — the one
-payload-plain command; see [grim fetch][commands-fetch].
+fields (`path`, `encoding`, `truncated`, `files`, `pointer`, `warnings`)
+are **omitted**, not null. Treat a missing key as its default. `encoding`
+is present only as `"base64"`, when `content` is the base64 of a non-UTF-8
+`--path` support file (plain mode decodes it back to the raw bytes). Its
+plain mode is the raw `content` payload (pipe-able, no report at all) — the
+one payload-plain command; see [grim fetch][commands-fetch].
 
 ## The error document {#error-document}
 
@@ -208,6 +211,7 @@ can ship in a minor release.
 [commands-status]: ./commands.md#status
 [commands-search]: ./commands.md#search
 [commands-context]: ./commands.md#context
+[commands-describe]: ./commands.md#describe
 [commands-fetch]: ./commands.md#fetch
 [commands-mcp]: ./commands.md#mcp
 [commands-config-json]: ./commands.md#config-json

--- a/docs/src/json-interface.md
+++ b/docs/src/json-interface.md
@@ -150,6 +150,37 @@ grim-specific codes above 78; the same table governs plain-mode exit
 codes. Clap parse failures (the pre-contract boundary above) and `--help`
 never produce the document.
 
+### The optional `reason` field {#error-reason}
+
+Some failures carry a machine-readable `reason` alongside `code`/`exit` —
+a kebab-case subtype that lets a consumer detect a *specific* refusal
+without scraping the non-frozen `message`:
+
+```json
+{
+  "error": {
+    "code": "data",
+    "exit": 65,
+    "reason": "stale-lock",
+    "message": "skill 'code-review' (…): partial-resolve refused: lock declaration_hash … does not match current …; retry with a full resolve"
+  }
+}
+```
+
+`reason` is **additive and optional**: it appears only when grim has a
+subtype for the failure and is **omitted** otherwise — an absent key, not
+`null` (the [`fetch` omit-empty fields](#fetch) set the precedent; the
+error document is likewise exempt from the [null policy](#null-policy)).
+A consumer must tolerate both its absence and a value it does not
+recognize. The reasons defined so far:
+
+| `reason` | Paired with | Meaning |
+|----------|-------------|---------|
+| `stale-lock` | `data` / 65 | A partial `grim update <name>` was refused because `grimoire.lock` no longer matches the current declaration. Retry with a full `grim update` (no names). |
+
+New reasons may appear in any minor release under the [additive-field
+policy][stability-additive]; existing ones never change meaning.
+
 ## Null and additive policy {#null-policy}
 
 Optional report fields are **always present**: a field that does not

--- a/docs/src/json-interface.md
+++ b/docs/src/json-interface.md
@@ -90,7 +90,7 @@ no kind at all, in which case `kind` is `null`.
 | `config get` | `{key, value, set, scope}` — see the [config JSON table][commands-config-json] | `scope`: `project`, `global` |
 | `config set` / `unset` / `registry add` / `rm` / `use` | `{action, key, value, scope}` | `action`: `set`, `unset`, `registry-added`, `registry-removed`, `registry-default` |
 | `config registry show` | `{alias, oci, index, default}` — both locator keys present, exactly one non-null | — |
-| `context` | `{version, scope, workspace, config_path, config_exists, lock_path, lock_exists, state_path, grim_home, offline, offline_source, clients, registries, default_registry}` — see [grim context][commands-context] | `offline_source`: `flag`, `env`, or null |
+| `context` | `{version, scope, workspace, config_path, config_exists, lock_path, lock_exists, state_path, grim_home, offline, offline_source, clients, registries, default_registry}`; `registries[]` is `{alias, url, kind, default, authenticated}` — see [grim context][commands-context] | `offline_source`: `flag`, `env`, or null |
 | `describe` | `{ref, digest, kind, name, title, description, summary, version, license, repository, revision, created, keywords, deprecated, replaced_by, tags, annotations}` — every field always present; `kind` is `null` for a foreign manifest; `keywords`/`tags` are `[]` when none; `annotations` is the verbatim manifest map; see [grim describe][commands-describe] | — |
 | `fetch` | `{ref, digest, kind, name, vendor, path?, content, encoding?, truncated?, files?, pointer?, warnings?}` — see [grim fetch](#fetch) | — |
 

--- a/docs/src/json-interface.md
+++ b/docs/src/json-interface.md
@@ -67,7 +67,7 @@ One row object per item inside `{"items": [...]}`:
 | `search` | `{kind, repo, summary, description, version, latest_tag, repository, revision, created, deprecated, replaced_by, status}` — `kind` is `null` when the catalog row's manifest declares none; `replaced_by` is the successor reference or `null`; see [grim search][commands-search] | `status`: install badge (`installed`, `not-installed`, …) |
 | `config list` | `{key, value}` | — |
 | `config registry list` | `{alias, oci, index, default}` — both locator keys present, exactly one non-null | — |
-| `publish` | `{ref, kind, digest, tags, status}` + sibling envelope key `announce` (`{outcome, branch, url}` or null) — see [publish report][publishing-report] | `status`: `pushed`, `skipped`, `dry-run`, `failed` |
+| `publish` | `{ref, kind, digest, tags, status}` + sibling envelope keys `descriptions` (`{"items": [...]}` of published/planned [description companion](./publishing.md#description-companion) pushes, `{ref, repository, digest, files}`, `digest` `null` under `--dry-run`; empty `items` when no companion was resolved) and `announce` (`{outcome, branch, url}` or null) — see [publish report][publishing-report] | `status`: `pushed`, `skipped`, `dry-run`, `failed` |
 
 `kind` is one of `skill`, `rule`, `agent`, `bundle`, `mcp` for every
 enveloped report except `search`: the other reports resolve a locked or
@@ -91,19 +91,73 @@ no kind at all, in which case `kind` is `null`.
 | `config set` / `unset` / `registry add` / `rm` / `use` | `{action, key, value, scope}` | `action`: `set`, `unset`, `registry-added`, `registry-removed`, `registry-default` |
 | `config registry show` | `{alias, oci, index, default}` — both locator keys present, exactly one non-null | — |
 | `context` | `{version, scope, workspace, config_path, config_exists, lock_path, lock_exists, state_path, grim_home, offline, offline_source, clients, registries, default_registry}`; `registries[]` is `{alias, url, kind, default, authenticated}` — see [grim context][commands-context] | `offline_source`: `flag`, `env`, or null |
-| `describe` | `{ref, digest, kind, name, title, description, summary, version, license, repository, revision, created, keywords, deprecated, replaced_by, tags, annotations}` — every field always present; `kind` is `null` for a foreign manifest; `keywords`/`tags` are `[]` when none; `annotations` is the verbatim manifest map; see [grim describe][commands-describe] | — |
-| `fetch` | `{ref, digest, kind, name, vendor, path?, content, encoding?, truncated?, files?, pointer?, warnings?}` — see [grim fetch](#fetch) | — |
+| `describe` | `{ref, digest, kind, name, title, description, has_description, summary, version, license, repository, revision, created, keywords, deprecated, replaced_by, tags, annotations}` — every field always present; `kind` is `null` for a foreign manifest; `has_description` is a boolean (whether the repository carries a [description companion](./publishing.md#description-companion), derived from the tag listing at zero extra network cost); `keywords`/`tags` are `[]` when none; `annotations` is the verbatim manifest map; see [grim describe][commands-describe] | — |
+| `fetch` | Tri-shaped by flags — content, description bundle, or digest probe — see [the fetch exception](#fetch) | — |
 
 ### The fetch exception {#fetch}
 
-`grim fetch` shares its JSON payload with the MCP `grim_fetch` tool, and
-that shape predates the [null policy](#null-policy): empty or default
-fields (`path`, `encoding`, `truncated`, `files`, `pointer`, `warnings`)
-are **omitted**, not null. Treat a missing key as its default. `encoding`
-is present only as `"base64"`, when `content` is the base64 of a non-UTF-8
-`--path` support file (plain mode decodes it back to the raw bytes). Its
-plain mode is the raw `content` payload (pipe-able, no report at all) — the
-one payload-plain command; see [grim fetch][commands-fetch].
+`grim fetch` shares its JSON payload with the MCP `grim_fetch` tool. Both
+route every call through the same neutral fetch core, so the report takes
+one of three shapes depending on the `--description` / `--digest-only`
+flags — each an untagged variant, its own flat JSON object. The shape
+predates the [null policy](#null-policy): empty or default fields are
+**omitted**, not null. Treat a missing key as its default.
+
+**Content** (default, `--vendor`, or `--path`) — the resolved artifact
+document: `{ref, digest, kind, name, vendor, path?, content, encoding?,
+truncated?, files?, pointer?, warnings?}`.
+
+```json
+{
+  "ref": "ghcr.io/acme/skills/code-review:1.2.0",
+  "digest": "sha256:…",
+  "kind": "skill",
+  "name": "code-review",
+  "vendor": "canonical",
+  "content": "---\nname: code-review\n…"
+}
+```
+
+`encoding` is present only as `"base64"`, when `content` is the base64 of
+a non-UTF-8 `--path` support file (plain mode decodes it back to the raw
+bytes). Its plain mode is the raw `content` payload (pipe-able, no report
+at all) — the one payload-plain command; see [grim fetch][commands-fetch].
+
+**Description bundle** (`--description`) — the repository's [description
+companion](./publishing.md#description-companion), every member inline:
+`{ref, digest, kind: "desc", files: [{path, size, content, encoding?}],
+warnings?}`.
+
+```json
+{
+  "ref": "ghcr.io/acme/mcp/postgres:__grimoire",
+  "digest": "sha256:…",
+  "kind": "desc",
+  "files": [
+    { "path": "README.md", "size": 812, "content": "…" },
+    { "path": "logo.svg", "size": 4096, "content": "…", "encoding": "base64" }
+  ]
+}
+```
+
+Bounded by the same 8 MiB layer gate as any fetch, with no per-file
+truncation — the whole companion returns in one call. A multi-file bundle
+has no single payload to print, so plain mode requires
+[`--out <dir>`](./commands.md#fetch-description) to unpack the tree to
+disk instead of printing JSON.
+
+**Digest probe** (`--digest-only`, optionally combined with
+`--description`) — a resolve-only cache key, no download: `{ref, digest,
+warnings?}`.
+
+```json
+{ "ref": "ghcr.io/acme/skills/code-review:1.2.0", "digest": "sha256:…" }
+```
+
+The reported digest equals the corresponding full fetch's manifest digest
+— the artifact's, or, combined with `--description`, the companion's — so
+a consumer caches on it and skips an unchanged download entirely. Plain
+mode prints the bare digest, no trailing newline.
 
 ## The error document {#error-document}
 
@@ -227,7 +281,12 @@ truncates a printed payload. Both share the same two download ceilings:
 the manifest's declared layer size is checked against the 8 MiB limit
 before download, and that declared size then bounds the actual streamed
 bytes — a registry serving more than it declared aborts mid-transfer into
-a data error (exit 65) on either interface.
+a data error (exit 65) on either interface. The tool's `description` and
+`digest_only` arguments select the same tri-shaped report the CLI flags
+do, with identical composition rules (`digest_only` with `description`
+probes the companion tag) — both interfaces call the same fetch core.
+`grim_describe` returns the same shape as `grim describe --format json`,
+including the `has_description` field.
 
 ## No self-identifying reports {#no-discriminator}
 

--- a/docs/src/mcp-servers.md
+++ b/docs/src/mcp-servers.md
@@ -271,10 +271,10 @@ than leaving a `"mcpServers": {}` husk behind.
 grim's own server is published at `ghcr.io/grimoire-rs/mcp/grim` from
 the source descriptor [`catalog/mcp/grim.toml`][catalog-mcp-grim] shown
 [above](#format), installable the same way as any third-party
-descriptor. Once registered it exposes four tools — `grim_search`,
-`grim_status`, `grim_fetch`, and (behind `--allow-writes`) `grim_render`
-— each taking the install scope as optional per-call arguments; the full
-tool table lives at [`grim mcp`](./commands.md#mcp).
+descriptor. Once registered it exposes five tools — `grim_search`,
+`grim_status`, `grim_fetch`, `grim_describe`, and (behind `--allow-writes`)
+`grim_render` — each taking the install scope as optional per-call
+arguments; the full tool table lives at [`grim mcp`](./commands.md#mcp).
 
 ## Limitations {#limitations}
 
@@ -293,9 +293,10 @@ tool table lives at [`grim mcp`](./commands.md#mcp).
 - **Copilot CLI's global config skips descriptors with `${VAR}`
   references** — see [Environment references](#env-references). Every
   other client and scope still installs normally.
-- **`grim_fetch` / `grim_render` need the network even with warm blobs.**
-  grim's cache stores blobs but not manifests, so under `GRIM_OFFLINE=1`
-  (or `--offline`) a fetch fails cleanly at the manifest lookup instead of
+- **`grim_fetch` / `grim_describe` / `grim_render` need the network even
+  with warm blobs.** grim's cache stores blobs but not manifests, so under
+  `GRIM_OFFLINE=1` (or `--offline`) these fail cleanly at the manifest
+  lookup (or, for an uncached reference, the digest resolution) instead of
   serving from cache. A manifest cache for true offline fetch is a tracked
   follow-up.
 - **A custom `$OPENCODE_CONFIG` outside every known root cannot be

--- a/docs/src/package-index.md
+++ b/docs/src/package-index.md
@@ -95,6 +95,8 @@ scripts/                           # (optional) build/validation tooling
   "kind": "skill",
   "ref": "ghcr.io/grimoire-rs/skills/grim-usage",
   "description": "Drive the grim CLI — install, update, search, publish.",
+  "summary": "Drive the grim CLI from an agent.",
+  "keywords": ["grim", "install", "search", "publish"],
   "repository": "https://github.com/grimoire-rs/grimoire",
   "owner": { "github": "grimoire-rs", "id": 298895348 }
 }
@@ -107,6 +109,8 @@ scripts/                           # (optional) build/validation tooling
 | `kind` | string | yes | One of `skill`, `rule`, `agent`, `mcp`, `bundle`. |
 | `ref` | string | yes | Fully-qualified OCI reference **without a tag**: `registry-host[/namespace]/repository`. MUST contain at least one `/`. MUST NOT carry a tag or digest — versions are resolved live. |
 | `description` | string | yes | One line, shown by `grim search` and the TUI. |
+| `summary` | string | no | Short single-line blurb, matched by `grim search` alongside `description` (distinct from it — usually shorter). |
+| `keywords` | array of string | no | Publisher keywords, matched by `grim search`. Omitted when empty. |
 | `repository` | string | no | Source repository URL. Consumers keep it only with an `https://` prefix. |
 | `owner.github` | string | yes* | GitHub login owning the namespace — for pointers under `index/github.com/` (and other GitHub-forge hosts). MUST match the namespace directory (case-insensitive). |
 | `owner.login` | string | yes* | The generic owner key for any non-GitHub host (the pointer's `index/<host>/` segment carries the forge context). MUST match the namespace directory (case-insensitive). |

--- a/docs/src/publishing.md
+++ b/docs/src/publishing.md
@@ -53,6 +53,38 @@ verbatim for every [client](./concepts.md#clients) — only the index is ever
 transformed. A rule with no support directory packs to exactly the single
 `my-rule.md` it always did.
 
+### Agents with a README and logo {#agent-companions}
+
+An [agent](./agents.md) is a single `.md`, but it may carry a `README.md` and a
+`logo.png`/`logo.svg` from a sibling directory sharing its stem — the same
+discovery as a rule's support directory, restricted to those well-known files:
+
+```
+agents/
+  code-reviewer.md        # the index you pass to build/release
+  code-reviewer/          # optional companion directory, same stem
+    README.md             # human-facing readme (shown by catalog UIs)
+    logo.png              # optional icon
+```
+
+Only `README.md`, `logo.png`, and `logo.svg` ride the layer (any other file in
+the directory is ignored, so an agent never becomes an accidental multi-file
+artifact). They pack under `code-reviewer/…`, so a consumer pulls them with the
+same path shape as a skill or rule:
+
+```sh
+grim fetch ghcr.io/acme/code-reviewer:1.0.0 --path code-reviewer/README.md
+```
+
+The companions are **not** installed to a client — an agent installs as its
+lone `.md` file; they exist for `grim fetch` and catalog UIs. An agent with no
+companion directory packs to exactly the single `code-reviewer.md` it always
+did.
+
+MCP servers and bundles publish a single JSON layer with no file tree, so they
+carry no README/logo companion — a catalog UI reads their `description` and
+`summary` from [`grim describe`](./commands.md#describe) instead.
+
 ## Catalog metadata {#metadata}
 
 [`grim search`](./commands.md#search) and the [TUI](./commands.md#tui) list

--- a/docs/src/publishing.md
+++ b/docs/src/publishing.md
@@ -81,9 +81,114 @@ lone `.md` file; they exist for `grim fetch` and catalog UIs. An agent with no
 companion directory packs to exactly the single `code-reviewer.md` it always
 did.
 
-MCP servers and bundles publish a single JSON layer with no file tree, so they
-carry no README/logo companion — a catalog UI reads their `description` and
-`summary` from [`grim describe`](./commands.md#describe) instead.
+MCP servers and bundles publish a single JSON layer with no file tree of their
+own, so they carry no *in-tree* README. For a README that works uniformly across
+every kind, publish a [repository description companion](#description-companion).
+
+## Repository description companion {#description-companion}
+
+The in-tree READMEs above ride each artifact's own layer, so they cover the
+tree-backed kinds (skill, rule, agent) but not mcp or bundle. A **description
+companion** is a repository-level channel that works for *every* kind: it is the
+one home for all of a repo's descriptive data — a `README.md`, a `CHANGELOG.md`,
+a logo, and any assets the README references — published to the reserved
+`__grimoire` tag in the same repository as each artifact.
+
+The companion is not a separate command — it rides
+[`grim publish`](#batch-publish). After each entry's artifact is pushed, grim
+(re)points that repository's `__grimoire` tag at a deterministic tar of the
+repo's descriptive files. The companion is marked `com.grimoire.kind: desc`; it
+is **not** an artifact kind, so it never installs, resolves, or appears in a
+catalog, and its reserved `__grimoire` tag is hidden from every user-facing tag
+listing (`grim describe` `tags[]`, the TUI version picker, catalog version
+selection). Direct resolution of the tag still works. Because the pack is
+byte-stable, republishing unchanged content produces an identical digest — the
+registry stores nothing new (the tag is always re-pointed, never gated by
+skip-existing).
+
+### Conventional layout {#description-probe}
+
+With no configuration at all, grim probes the manifest directory for the
+conventional files and publishes a companion when it finds any:
+
+| Source (relative to `publish.toml`) | Packed as |
+|-------------------------------------|-----------|
+| `README.md` | `README.md` |
+| `CHANGELOG.md` | `CHANGELOG.md` |
+| `assets/logo.png` / `assets/logo.svg` / `logo.png` / `logo.svg` (first hit) | `logo.png` / `logo.svg` |
+
+Every member is optional — a repo with just a `README.md` publishes a
+one-file companion. Probe misses are silent: a manifest directory with none of
+these files simply publishes no companion, which is not an error.
+
+### The `[description]` table {#description-table}
+
+To decouple the companion from your repository layout — or to add extra
+assets — declare a `[description]` table. Its paths are relative to
+`publish.toml`, and the well-known members map their source onto the fixed
+wire name, so your repo can lay files out however it likes:
+
+```toml
+[description]                     # optional; fans out to every entry
+readme    = "docs/readme.md"      # → packed as README.md
+logo      = "assets/brand.svg"    # → packed as logo.svg (by extension)
+changelog = "CHANGELOG.md"        # → packed as CHANGELOG.md
+include   = ["docs/img/*.png"]    # extra assets — keep their relative path
+# publish = false                 # manifest-wide kill switch
+```
+
+`include` globs (`*`/`?` within a segment, `**` across segments) pull in
+README-referenced assets; each hit keeps its manifest-relative path on the
+wire. An explicit `readme`/`logo`/`changelog` path that does not exist is a
+data error (exit 65) — an explicit config must not silently skip. A
+`[description]` table that resolves to zero files is likewise a data error;
+`publish = false` disables the auto-companion for the whole manifest.
+
+### Fan-out, override, and opt-out {#description-fanout}
+
+A top-level `[description]` publishes the **same** companion to every entry's
+repository. A per-entry table overrides it for one entry, and
+`description = false` opts an entry out:
+
+```toml
+[description]
+readme = "README.md"                 # every repo gets this by default
+
+[skills.grim-usage]
+repository = "grimoire-rs/skills/grim-usage"
+[skills.grim-usage.description]      # per-entry override (same schema)
+readme = "skills/grim-usage/README.md"
+
+[mcp.grim]
+repository = "grimoire-rs/mcp/grim"
+description = false                  # this repo gets no companion
+```
+
+A `--dry-run` publish lists the planned companion pushes (`descriptions` in
+the [JSON report](#batch-publish-report), digest `null`) without touching the
+registry, so you can confirm the fan-out before it happens.
+
+### Read it back {#description-read}
+
+Read the companion with
+[`grim fetch --description`](./commands.md#fetch-description) — the
+reserved `__grimoire` tag is a grim-internal implementation detail; the
+flag is the documented way to reach it, so nothing outside grim needs to
+type or know the tag:
+
+```sh
+grim fetch ghcr.io/acme/mcp/postgres --description                              # every packed file inline
+grim fetch ghcr.io/acme/mcp/postgres --description --format json | jq '.files[].path'
+grim fetch ghcr.io/acme/mcp/postgres --description --out ./docs                 # unpack the tree to disk
+```
+
+`--format json` reports `kind: "desc"` and every packed file inline in
+`files[]` — README, logo, changelog, and any README-referenced assets — in
+one call, bounded by the same 8 MiB layer gate as any fetch. A repository
+with no companion published returns a clean *not-found* error, so a
+consumer can fall back to an in-tree README. [`grim describe`](./commands.md#describe)'s
+`has_description` field answers "does this repository have one?" without
+a probe fetch at all.
 
 ## Catalog metadata {#metadata}
 
@@ -763,6 +868,16 @@ wrapper object on stdout:
       "status": "pushed"
     }
   ],
+  "descriptions": {
+    "items": [
+      {
+        "ref": "ghcr.io/acme/skills/code-review:__grimoire",
+        "repository": "ghcr.io/acme/skills/code-review",
+        "digest": "sha256:…",
+        "files": ["README.md"]
+      }
+    ]
+  },
   "announce": {
     "outcome": "pull-request",
     "branch": "announce/acme-1a2b3c4d",
@@ -772,7 +887,13 @@ wrapper object on stdout:
 ```
 
 `items` carries one object per manifest entry processed, in publish
-order. `announce` carries the completed `--announce` outcome: `outcome`
+order. `descriptions` carries the [description companion](#description-companion)
+pushes this run, one per distinct target repository, in the same
+`{"items": [...]}` envelope as every multi-item report; `items` is empty
+when no companion was resolved for this run. Each entry's `digest` is
+`null` under `--dry-run` (the preview lists the planned push without
+touching the registry). `announce` carries the completed `--announce`
+outcome: `outcome`
 is `pull-request`, `branch-pushed`, or `up-to-date`; `branch` — the
 deterministic topic branch on the index repository — is always present;
 `url` is always present and non-null only for `pull-request`. `announce` is `null` whenever the

--- a/docs/src/publishing.md
+++ b/docs/src/publishing.md
@@ -57,7 +57,7 @@ transformed. A rule with no support directory packs to exactly the single
 
 [`grim search`](./commands.md#search) and the [TUI](./commands.md#tui) list
 every match in a table. To make a result legible and findable, an artifact
-carries five pieces of catalog metadata, all optional:
+carries six pieces of catalog metadata, all optional:
 
 | Field | Annotation | Purpose |
 |-------|-----------|---------|
@@ -66,6 +66,7 @@ carries five pieces of catalog metadata, all optional:
 | `description` | `org.opencontainers.image.description` | The full description. |
 | `repository` | `org.opencontainers.image.source` | HTTPS URL of the artifact's source repository ([details](#metadata-repository)). |
 | `deprecated` | `com.grimoire.deprecated` | A deprecation notice; marks the package deprecated and flags it everywhere ([details](#metadata-deprecated)). |
+| `replaced-by` | `com.grimoire.replaced-by` | A reference naming the successor artifact ([details](#metadata-replaced-by)). |
 
 `grim search` shows the `summary` in place of the `description`, truncated to
 fit the terminal; the full description stays in `--format json` and in piped
@@ -243,6 +244,39 @@ manifest, every surface reads it back without unpacking the artifact:
 
 A re-release with the notice removed clears the deprecation — the annotation
 simply stops being emitted.
+
+### Naming a replacement {#metadata-replaced-by}
+
+`replaced-by` points a consumer at the successor artifact. It is authored
+independently of `deprecated` — a package can name a replacement without
+being deprecated (a rename that keeps working), or be deprecated with no
+single successor — so the two keys are emitted and read separately. The
+value must parse as an artifact reference; `grim build` / `grim release`
+reject an unparseable value with exit 65, the same gate as the repository
+URL. An empty or whitespace-only value emits no annotation.
+
+```yaml
+# code-review/SKILL.md (skill / agent: under the metadata map)
+metadata:
+  replaced-by: ghcr.io/acme/skills/code-review-2
+```
+
+```yaml
+# rust-style.md (rule: top-level, like summary)
+replaced-by: ghcr.io/acme/rules/rust-style-2
+```
+
+```toml
+# python-stack.toml (bundle: top-level)
+replaced-by = "ghcr.io/acme/bundles/python-stack-2"
+```
+
+The reference rides the `com.grimoire.replaced-by` annotation on the
+manifest, so [`grim search`](./commands.md#search) and
+[`grim describe`](./commands.md#describe) expose it as a `replaced_by` field
+in `--format json` (`null` when none). It pairs naturally with `deprecated`:
+deprecate the old package and name its replacement, and a consumer sees both
+the notice and where to go next.
 
 ## Validate before you push
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -14,6 +14,7 @@ pub mod artifact_status;
 pub mod build_report;
 pub mod config_report;
 pub mod context_report;
+pub mod describe_report;
 pub mod fetch_report;
 pub mod init_report;
 pub mod install_report;
@@ -40,6 +41,8 @@ pub use config_report::{
 };
 #[allow(unused_imports)]
 pub use context_report::{ContextRegistry, ContextRegistryKind, ContextReport, OfflineSource};
+#[allow(unused_imports)]
+pub use describe_report::DescribeCliReport;
 #[allow(unused_imports)]
 pub use fetch_report::FetchCliReport;
 #[allow(unused_imports)]

--- a/src/api/context_report.rs
+++ b/src/api/context_report.rs
@@ -14,7 +14,9 @@
 //! or `null` (when online); `clients` is the effective client-target
 //! name list (names only — vendor on-disk layout is unstable, and
 //! `grim status --format json` `outputs` is the path channel);
-//! `registries` is `[{alias, url, kind, default}]`.
+//! `registries` is `[{alias, url, kind, default, authenticated}]`
+//! (`authenticated`: a credential for the registry's host is present in the
+//! docker-compatible store).
 
 use std::io::{self, Write};
 use std::path::PathBuf;
@@ -54,6 +56,11 @@ pub struct ContextRegistry {
     /// Whether this is the primary registry short identifiers expand
     /// against.
     pub default: bool,
+    /// Whether a credential for this registry's host is present in the
+    /// docker-compatible store (a file-only probe — a global `credsStore`
+    /// with no per-host entry does not count). See
+    /// [`crate::auth::store::DockerCredentialStore::has_credential`].
+    pub authenticated: bool,
 }
 
 /// Where the effective offline mode came from.
@@ -148,9 +155,10 @@ impl Printable for ContextReport {
         for r in &self.registries {
             let alias = r.alias.as_deref().unwrap_or("-");
             let default = if r.default { ", default" } else { "" };
+            let auth = if r.authenticated { ", authenticated" } else { "" };
             rows.push(vec![
                 "registry".into(),
-                format!("{alias} {} ({}{default})", r.url, r.kind),
+                format!("{alias} {} ({}{default}{auth})", r.url, r.kind),
             ]);
         }
         rows.push(vec!["default_registry".into(), self.default_registry.clone()]);
@@ -186,6 +194,7 @@ mod tests {
                 url: "ghcr.io/acme".to_string(),
                 kind: ContextRegistryKind::Registry,
                 default: true,
+                authenticated: true,
             }],
             default_registry: "ghcr.io/acme".to_string(),
         }
@@ -201,6 +210,7 @@ mod tests {
         assert!(out.contains("claude,opencode"));
         assert!(out.contains("true (flag)"));
         assert!(out.contains("ghcr.io/acme"));
+        assert!(out.contains(", authenticated"));
         assert!(out.contains("(exists)"));
         assert!(out.contains("(absent)"));
     }
@@ -220,7 +230,14 @@ mod tests {
         assert_eq!(v["registries"][0]["alias"], "acme");
         assert_eq!(v["registries"][0]["kind"], "registry");
         assert_eq!(v["registries"][0]["default"], true);
+        assert_eq!(v["registries"][0]["authenticated"], true);
         assert_eq!(v["default_registry"], "ghcr.io/acme");
+
+        // `authenticated` is a plain always-present bool in both states.
+        let mut r = report();
+        r.registries[0].authenticated = false;
+        let v = serde_json::to_value(&r).unwrap();
+        assert_eq!(v["registries"][0]["authenticated"], false);
 
         // Always-present-null: offline_source is an explicit null online.
         let mut r = report();

--- a/src/api/describe_report.rs
+++ b/src/api/describe_report.rs
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The Grimoire Authors
+
+//! `grim describe` output.
+//!
+//! Plain format: one two-column key/value table (Key | Value) — one row per
+//! curated field, `keywords` and `tags` comma-joined, absent fields shown as
+//! `-`. Modelled on `grim context`. The verbatim `annotations` map is
+//! JSON-only (the curated rows already surface the meaningful keys).
+//!
+//! JSON format: the full [`DescribeReport`] single object — every field
+//! always present, `null` when absent, `[]`/`{}` for the empty collections
+//! (subsystem-cli-api.md single-object null policy).
+
+use std::io::{self, Write};
+
+use serde::Serialize;
+
+use crate::cli::printer::{Printable, print_table};
+use crate::fetch::DescribeReport;
+
+/// Newtype wrapping the shared describe payload for CLI rendering.
+#[derive(Debug, Serialize)]
+#[serde(transparent)]
+pub struct DescribeCliReport(pub DescribeReport);
+
+impl Printable for DescribeCliReport {
+    fn print_plain(&self, w: &mut impl Write) -> io::Result<()> {
+        let d = &self.0;
+        let opt = |v: &Option<String>| v.clone().unwrap_or_else(|| "-".to_string());
+        let list = |v: &[String]| if v.is_empty() { "-".to_string() } else { v.join(",") };
+        let rows: Vec<Vec<String>> = vec![
+            vec!["ref".into(), d.reference.clone()],
+            vec!["digest".into(), d.digest.clone()],
+            vec!["kind".into(), opt(&d.kind)],
+            vec!["name".into(), d.name.clone()],
+            vec!["title".into(), opt(&d.title)],
+            vec!["description".into(), opt(&d.description)],
+            vec!["summary".into(), opt(&d.summary)],
+            vec!["version".into(), opt(&d.version)],
+            vec!["license".into(), opt(&d.license)],
+            vec!["repository".into(), opt(&d.repository)],
+            vec!["revision".into(), opt(&d.revision)],
+            vec!["created".into(), opt(&d.created)],
+            vec!["keywords".into(), list(&d.keywords)],
+            vec!["deprecated".into(), opt(&d.deprecated)],
+            vec!["replaced_by".into(), opt(&d.replaced_by)],
+            vec!["tags".into(), list(&d.tags)],
+        ];
+        print_table(w, &["Key", "Value"], &rows)
+    }
+
+    fn print_json(&self, w: &mut impl Write) -> io::Result<()> {
+        let json = serde_json::to_string_pretty(&self.0).map_err(io::Error::other)?;
+        writeln!(w, "{json}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    fn report() -> DescribeCliReport {
+        let mut annotations = BTreeMap::new();
+        annotations.insert("com.grimoire.kind".to_string(), "skill".to_string());
+        annotations.insert("org.opencontainers.image.title".to_string(), "code-review".to_string());
+        DescribeCliReport(DescribeReport {
+            reference: "ghcr.io/acme/skills/code-review:latest".to_string(),
+            digest: format!("sha256:{}", "a".repeat(64)),
+            kind: Some("skill".to_string()),
+            name: "code-review".to_string(),
+            title: Some("code-review".to_string()),
+            description: Some("Review code.".to_string()),
+            summary: Some("terse blurb".to_string()),
+            version: Some("1.2.0".to_string()),
+            license: Some("Apache-2.0".to_string()),
+            repository: Some("https://github.com/acme/code-review".to_string()),
+            revision: None,
+            created: None,
+            keywords: vec!["review".to_string(), "quality".to_string()],
+            deprecated: None,
+            replaced_by: Some("ghcr.io/acme/skills/code-review-2".to_string()),
+            tags: vec!["1.2.0".to_string(), "latest".to_string()],
+            annotations,
+        })
+    }
+
+    #[test]
+    fn plain_is_single_key_value_table() {
+        let mut buf = Vec::new();
+        report().print_plain(&mut buf).unwrap();
+        let out = String::from_utf8(buf).unwrap();
+        assert!(out.lines().next().unwrap().starts_with("Key"));
+        assert!(out.contains("skill"));
+        assert!(out.contains("review,quality"), "keywords comma-joined");
+        assert!(out.contains("1.2.0,latest"), "tags comma-joined");
+        assert!(out.contains("ghcr.io/acme/skills/code-review-2"));
+    }
+
+    #[test]
+    fn json_is_single_object_all_fields_present() {
+        let mut buf = Vec::new();
+        report().print_json(&mut buf).unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&buf).unwrap();
+        assert!(v.is_object());
+        assert_eq!(v["ref"], "ghcr.io/acme/skills/code-review:latest");
+        assert_eq!(v["kind"], "skill");
+        assert_eq!(v["keywords"], serde_json::json!(["review", "quality"]));
+        assert_eq!(v["tags"], serde_json::json!(["1.2.0", "latest"]));
+        assert_eq!(v["replaced_by"], "ghcr.io/acme/skills/code-review-2");
+        assert_eq!(v["annotations"]["com.grimoire.kind"], "skill");
+        // Always-present-null: an absent curated field is explicit null.
+        assert!(v.get("revision").expect("key present").is_null());
+        assert!(v.get("deprecated").expect("key present").is_null());
+    }
+}

--- a/src/api/describe_report.rs
+++ b/src/api/describe_report.rs
@@ -36,6 +36,7 @@ impl Printable for DescribeCliReport {
             vec!["name".into(), d.name.clone()],
             vec!["title".into(), opt(&d.title)],
             vec!["description".into(), opt(&d.description)],
+            vec!["has_description".into(), d.has_description.to_string()],
             vec!["summary".into(), opt(&d.summary)],
             vec!["version".into(), opt(&d.version)],
             vec!["license".into(), opt(&d.license)],
@@ -72,6 +73,7 @@ mod tests {
             name: "code-review".to_string(),
             title: Some("code-review".to_string()),
             description: Some("Review code.".to_string()),
+            has_description: true,
             summary: Some("terse blurb".to_string()),
             version: Some("1.2.0".to_string()),
             license: Some("Apache-2.0".to_string()),
@@ -93,6 +95,7 @@ mod tests {
         let out = String::from_utf8(buf).unwrap();
         assert!(out.lines().next().unwrap().starts_with("Key"));
         assert!(out.contains("skill"));
+        assert!(out.contains("has_description"), "companion presence row present");
         assert!(out.contains("review,quality"), "keywords comma-joined");
         assert!(out.contains("1.2.0,latest"), "tags comma-joined");
         assert!(out.contains("ghcr.io/acme/skills/code-review-2"));
@@ -106,6 +109,7 @@ mod tests {
         assert!(v.is_object());
         assert_eq!(v["ref"], "ghcr.io/acme/skills/code-review:latest");
         assert_eq!(v["kind"], "skill");
+        assert_eq!(v["has_description"], true, "always-present companion flag");
         assert_eq!(v["keywords"], serde_json::json!(["review", "quality"]));
         assert_eq!(v["tags"], serde_json::json!(["1.2.0", "latest"]));
         assert_eq!(v["replaced_by"], "ghcr.io/acme/skills/code-review-2");

--- a/src/api/fetch_report.rs
+++ b/src/api/fetch_report.rs
@@ -14,6 +14,8 @@
 
 use std::io::{self, Write};
 
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD as BASE64;
 use serde::Serialize;
 
 use crate::cli::printer::Printable;
@@ -26,7 +28,13 @@ pub struct FetchCliReport(pub FetchReport);
 
 impl Printable for FetchCliReport {
     /// Raw content bytes — no trailing newline is added (payload purity).
+    /// A base64-encoded binary support file decodes back to its exact bytes
+    /// so `grim fetch ref --path x/logo.png > logo.png` round-trips.
     fn print_plain(&self, w: &mut impl Write) -> io::Result<()> {
+        if self.0.encoding.as_deref() == Some("base64") {
+            let bytes = BASE64.decode(self.0.content.as_bytes()).map_err(io::Error::other)?;
+            return w.write_all(&bytes);
+        }
         w.write_all(self.0.content.as_bytes())
     }
 
@@ -49,6 +57,7 @@ mod tests {
             vendor: "canonical".to_string(),
             path: None,
             content: content.to_string(),
+            encoding: None,
             truncated: false,
             files: Vec::new(),
             pointer: None,
@@ -61,6 +70,20 @@ mod tests {
         let mut buf = Vec::new();
         report("# Demo").print_plain(&mut buf).unwrap();
         assert_eq!(buf, b"# Demo", "no added newline, no table");
+    }
+
+    #[test]
+    fn plain_decodes_base64_binary_to_raw_bytes() {
+        // A base64-encoded binary support file decodes back byte-identical
+        // in plain mode so a stdout redirect round-trips.
+        let raw: &[u8] = &[0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x00, 0xff];
+        let mut r = report("");
+        r.0.content = BASE64.encode(raw);
+        r.0.encoding = Some("base64".to_string());
+        r.0.path = Some("demo/logo.png".to_string());
+        let mut buf = Vec::new();
+        r.print_plain(&mut buf).unwrap();
+        assert_eq!(buf, raw, "base64 decodes back to the exact bytes");
     }
 
     #[test]

--- a/src/api/fetch_report.rs
+++ b/src/api/fetch_report.rs
@@ -3,14 +3,18 @@
 
 //! `grim fetch` output.
 //!
-//! **Payload-plain report** (documented exemption in
-//! subsystem-cli-api.md): plain format is the raw `content` payload —
-//! exact bytes, no table, no added trailing newline — so
-//! `grim fetch ref --path X > file` round-trips. JSON format is the full
-//! [`FetchReport`] object
-//! (`{ref, digest, kind, name, vendor, path?, content, truncated?,
-//! files?, pointer?, warnings?}` — MCP-shaped, empty/default fields
-//! omitted).
+//! **Payload-plain report** (documented exemption in subsystem-cli-api.md):
+//! plain format is the raw `content` payload — exact bytes, no table, no
+//! added trailing newline — so `grim fetch ref --path X > file` round-trips.
+//! JSON format is the full tri-shaped [`FetchOutcome`] (content object /
+//! description bundle / digest probe), MCP-shaped, empty/default fields
+//! omitted.
+//!
+//! Plain mode by outcome: **content** is the raw payload; a **description**
+//! bundle has no single payload (plain is only reached with `--out`, whose
+//! files the command already wrote to disk) so stdout stays empty; a
+//! **digest** probe prints the bare digest (no trailing newline, pipes
+//! cleanly).
 
 use std::io::{self, Write};
 
@@ -19,23 +23,31 @@ use base64::engine::general_purpose::STANDARD as BASE64;
 use serde::Serialize;
 
 use crate::cli::printer::Printable;
-use crate::fetch::FetchReport;
+use crate::fetch::FetchOutcome;
 
-/// Newtype wrapping the shared MCP fetch payload for CLI rendering.
+/// Newtype wrapping the tri-shaped fetch outcome for CLI rendering.
 #[derive(Debug, Serialize)]
 #[serde(transparent)]
-pub struct FetchCliReport(pub FetchReport);
+pub struct FetchCliReport(pub FetchOutcome);
 
 impl Printable for FetchCliReport {
-    /// Raw content bytes — no trailing newline is added (payload purity).
-    /// A base64-encoded binary support file decodes back to its exact bytes
-    /// so `grim fetch ref --path x/logo.png > logo.png` round-trips.
+    /// Raw payload bytes — no trailing newline is added (payload purity). A
+    /// base64-encoded binary support file decodes back to its exact bytes so
+    /// `grim fetch ref --path x/logo.png > logo.png` round-trips.
     fn print_plain(&self, w: &mut impl Write) -> io::Result<()> {
-        if self.0.encoding.as_deref() == Some("base64") {
-            let bytes = BASE64.decode(self.0.content.as_bytes()).map_err(io::Error::other)?;
-            return w.write_all(&bytes);
+        match &self.0 {
+            FetchOutcome::Content(r) => {
+                if r.encoding.as_deref() == Some("base64") {
+                    let bytes = BASE64.decode(r.content.as_bytes()).map_err(io::Error::other)?;
+                    return w.write_all(&bytes);
+                }
+                w.write_all(r.content.as_bytes())
+            }
+            // The companion tree was already unpacked to `--out` by the
+            // command (plain is unreachable without it); stdout stays empty.
+            FetchOutcome::Description(_) => Ok(()),
+            FetchOutcome::Digest(r) => w.write_all(r.digest.as_bytes()),
         }
-        w.write_all(self.0.content.as_bytes())
     }
 
     fn print_json(&self, w: &mut impl Write) -> io::Result<()> {
@@ -47,22 +59,27 @@ impl Printable for FetchCliReport {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::fetch::{DescriptionFile, DescriptionReport, DigestReport, FetchReport};
 
-    fn report(content: &str) -> FetchCliReport {
-        FetchCliReport(FetchReport {
+    fn content(body: &str) -> FetchReport {
+        FetchReport {
             reference: "ghcr.io/acme/skills/demo:latest".to_string(),
             digest: format!("sha256:{}", "a".repeat(64)),
             kind: "skill".to_string(),
             name: "demo".to_string(),
             vendor: "canonical".to_string(),
             path: None,
-            content: content.to_string(),
+            content: body.to_string(),
             encoding: None,
             truncated: false,
             files: Vec::new(),
             pointer: None,
             warnings: Vec::new(),
-        })
+        }
+    }
+
+    fn report(body: &str) -> FetchCliReport {
+        FetchCliReport(FetchOutcome::Content(Box::new(content(body))))
     }
 
     #[test]
@@ -77,10 +94,11 @@ mod tests {
         // A base64-encoded binary support file decodes back byte-identical
         // in plain mode so a stdout redirect round-trips.
         let raw: &[u8] = &[0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x00, 0xff];
-        let mut r = report("");
-        r.0.content = BASE64.encode(raw);
-        r.0.encoding = Some("base64".to_string());
-        r.0.path = Some("demo/logo.png".to_string());
+        let mut c = content("");
+        c.content = BASE64.encode(raw);
+        c.encoding = Some("base64".to_string());
+        c.path = Some("demo/logo.png".to_string());
+        let r = FetchCliReport(FetchOutcome::Content(Box::new(c)));
         let mut buf = Vec::new();
         r.print_plain(&mut buf).unwrap();
         assert_eq!(buf, raw, "base64 decodes back to the exact bytes");
@@ -96,5 +114,69 @@ mod tests {
         assert_eq!(v["vendor"], "canonical");
         assert_eq!(v["content"], "# Demo\n");
         assert!(v["digest"].as_str().unwrap().starts_with("sha256:"));
+    }
+
+    #[test]
+    fn description_json_is_bundle_and_plain_is_empty() {
+        let outcome = FetchOutcome::Description(DescriptionReport {
+            reference: "ghcr.io/acme/skills/demo:__grimoire".to_string(),
+            digest: format!("sha256:{}", "b".repeat(64)),
+            kind: "desc".to_string(),
+            files: vec![
+                DescriptionFile {
+                    path: "README.md".to_string(),
+                    size: 6,
+                    content: "# Repo".to_string(),
+                    encoding: None,
+                },
+                DescriptionFile {
+                    path: "logo.png".to_string(),
+                    size: 2,
+                    content: BASE64.encode([0x89, 0x50]),
+                    encoding: Some("base64".to_string()),
+                },
+            ],
+            warnings: Vec::new(),
+        });
+        let r = FetchCliReport(outcome);
+
+        let mut json = Vec::new();
+        r.print_json(&mut json).unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&json).unwrap();
+        assert_eq!(v["kind"], "desc");
+        assert_eq!(v["files"][0]["path"], "README.md");
+        assert_eq!(v["files"][0]["content"], "# Repo");
+        assert!(v["files"][0].get("encoding").is_none(), "text member omits encoding");
+        assert_eq!(v["files"][1]["encoding"], "base64");
+
+        // A bundle has no single plain payload — stdout stays empty.
+        let mut plain = Vec::new();
+        r.print_plain(&mut plain).unwrap();
+        assert!(
+            plain.is_empty(),
+            "description plain payload is empty (files went to --out)"
+        );
+    }
+
+    #[test]
+    fn digest_probe_plain_is_bare_digest_and_json_is_ref_digest() {
+        let digest = format!("sha256:{}", "c".repeat(64));
+        let outcome = FetchOutcome::Digest(DigestReport {
+            reference: "ghcr.io/acme/skills/demo:latest".to_string(),
+            digest: digest.clone(),
+            warnings: Vec::new(),
+        });
+        let r = FetchCliReport(outcome);
+
+        let mut plain = Vec::new();
+        r.print_plain(&mut plain).unwrap();
+        assert_eq!(plain, digest.as_bytes(), "plain payload is the bare digest, no newline");
+
+        let mut json = Vec::new();
+        r.print_json(&mut json).unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&json).unwrap();
+        assert_eq!(v["ref"], "ghcr.io/acme/skills/demo:latest");
+        assert_eq!(v["digest"], digest);
+        assert!(v.get("kind").is_none(), "digest probe carries no kind");
     }
 }

--- a/src/api/publish_report.rs
+++ b/src/api/publish_report.rs
@@ -6,11 +6,14 @@
 //! Plain format: 5-column table (Kind | Ref | Digest | Tags | Status);
 //! the announce outcome stays human prose on stderr.
 //!
-//! JSON format: `{"items": [...], "announce": ...}` (uniform `items`
-//! envelope, per subsystem-cli-api.md). `items` is the per-entry array
-//! (`{kind, ref, digest, tags, status}`); `announce` is
-//! `{outcome, branch, url}` when the `--announce` step completed, else
-//! `null` (no `--announce`, dry run, fail-fast, or announce failure).
+//! JSON format: `{"items": [...], "descriptions": {...}, "announce": ...}`
+//! (uniform `items` envelope, per subsystem-cli-api.md). `items` is the
+//! per-entry array (`{kind, ref, digest, tags, status}`); `descriptions` is a
+//! sibling `{"items": [...]}` of published description companions
+//! (`{ref, repository, digest, files}`, digest `null` under `--dry-run`);
+//! `announce` is `{outcome, branch, url}` when the `--announce` step
+//! completed, else `null` (no `--announce`, dry run, fail-fast, or announce
+//! failure).
 
 use std::io::{self, Write};
 
@@ -101,6 +104,32 @@ pub struct PublishAnnounce {
     pub url: Option<String>,
 }
 
+/// One published (or, under `--dry-run`, planned) description companion.
+///
+/// The companion re-points a repository's reserved `__grimoire` tag at a tar
+/// of the repo's descriptive files (README, logo, changelog, extra assets).
+#[derive(Debug, Serialize)]
+pub struct PublishDescription {
+    /// The companion reference (`registry/repo:__grimoire`).
+    #[serde(rename = "ref")]
+    pub reference: String,
+    /// The target repository (`registry/repo`, no tag).
+    pub repository: String,
+    /// The pushed manifest digest; `null` under `--dry-run` (nothing pushed).
+    pub digest: Option<String>,
+    /// The packed file names, in on-wire (sorted) order.
+    pub files: Vec<String>,
+}
+
+/// The `descriptions` section of the publish report: the description
+/// companions published this run, one per distinct repository, in the uniform
+/// `{"items": [...]}` envelope. Empty when no companion was resolved.
+#[derive(Debug, Default, Serialize)]
+pub struct PublishDescriptions {
+    /// Per-repository companion outcomes, in publish order.
+    items: Vec<PublishDescription>,
+}
+
 /// One row in the publish report: the outcome of a single manifest entry.
 #[derive(Debug, Serialize)]
 pub struct PublishEntry {
@@ -130,15 +159,29 @@ fn serialize_kind<S: Serializer>(kind: &ArtifactKind, s: S) -> Result<S::Ok, S::
 pub struct PublishReport {
     /// Per-entry outcomes, in publish order.
     items: Vec<PublishEntry>,
+    /// The description companions published this run (uniform `items`
+    /// envelope); empty `items` when no companion was resolved.
+    descriptions: PublishDescriptions,
     /// The completed `--announce` outcome; `None` when announce did not
     /// run to completion (not requested, dry run, fail-fast, failure).
     announce: Option<PublishAnnounce>,
 }
 
 impl PublishReport {
-    /// Build from operation results (no completed announce).
+    /// Build from operation results (no companions, no completed announce).
     pub fn new(items: Vec<PublishEntry>) -> Self {
-        Self { items, announce: None }
+        Self {
+            items,
+            descriptions: PublishDescriptions::default(),
+            announce: None,
+        }
+    }
+
+    /// Attach the published description companions (consuming builder).
+    #[must_use]
+    pub fn with_descriptions(mut self, items: Vec<PublishDescription>) -> Self {
+        self.descriptions = PublishDescriptions { items };
+        self
     }
 
     /// Attach the completed `--announce` outcome (consuming builder).
@@ -176,7 +219,7 @@ fn truncate_digest(digest: &str) -> String {
 
 impl Printable for PublishReport {
     fn print_plain(&self, w: &mut impl Write) -> io::Result<()> {
-        let rows: Vec<Vec<String>> = self
+        let mut rows: Vec<Vec<String>> = self
             .items
             .iter()
             .map(|e| {
@@ -192,6 +235,21 @@ impl Printable for PublishReport {
                 ]
             })
             .collect();
+        // Description companions share the single table as `desc` rows so a
+        // plain `--dry-run` previews the planned fan-out (ADR risk
+        // mitigation). No digest ⇒ nothing was pushed ⇒ dry-run.
+        rows.extend(self.descriptions.items.iter().map(|d| {
+            vec![
+                "desc".to_string(),
+                d.reference.clone(),
+                d.digest
+                    .as_deref()
+                    .map(truncate_digest)
+                    .unwrap_or_else(|| "-".to_string()),
+                "-".to_string(), // files live in JSON; the companion tag is in the ref
+                if d.digest.is_some() { "pushed" } else { "dry-run" }.to_string(),
+            ]
+        }));
         print_table(w, &["Kind", "Ref", "Digest", "Tags", "Status"], &rows)
     }
 
@@ -248,6 +306,31 @@ mod tests {
             "plain digest must not contain full hex, got: {}",
             lines[1]
         );
+    }
+
+    #[test]
+    fn plain_appends_description_rows_to_the_single_table() {
+        let r = PublishReport::new(vec![PublishEntry {
+            reference: "registry.example/acme/s:1.0.0".to_string(),
+            kind: ArtifactKind::Skill,
+            digest: None,
+            tags: vec![],
+            status: PublishStatus::DryRun,
+        }])
+        .with_descriptions(vec![PublishDescription {
+            reference: "registry.example/acme/s:__grimoire".to_string(),
+            repository: "registry.example/acme/s".to_string(),
+            digest: None,
+            files: vec!["README.md".to_string()],
+        }]);
+        let mut buf = Vec::new();
+        r.print_plain(&mut buf).unwrap();
+        let out = String::from_utf8(buf).unwrap();
+        let lines: Vec<&str> = out.lines().collect();
+        assert_eq!(lines.len(), 3, "header + entry + companion row");
+        assert!(lines[2].starts_with("desc"));
+        assert!(lines[2].contains(":__grimoire"));
+        assert!(lines[2].contains("dry-run"));
     }
 
     #[test]

--- a/src/api/search_report.rs
+++ b/src/api/search_report.rs
@@ -67,6 +67,10 @@ pub struct SearchEntry {
 impl Serialize for SearchEntry {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         use serde::ser::SerializeStruct;
+        // Manual impl (not derive) because `status` projects through Display.
+        // Field count below is asserted by
+        // `json_carries_replaced_by_plain_table_does_not` — adding a field
+        // here requires bumping both, or the test fails.
         let mut s = serializer.serialize_struct("SearchEntry", 12)?;
         s.serialize_field("kind", &self.kind)?;
         s.serialize_field("repo", &self.repo)?;
@@ -466,7 +470,9 @@ mod tests {
         SearchReport::new(vec![e.clone()]).print_json(&mut buf).unwrap();
         let v: serde_json::Value = serde_json::from_slice(&buf).unwrap();
         assert_eq!(v["items"][0]["replaced_by"], "ghcr.io/acme/skills/x2");
-        // The full 12-field object still round-trips (manual Serialize count).
+        // The full 12-field object still round-trips. This count is linked to
+        // the manual `Serialize for SearchEntry` impl's serialize_struct count
+        // — the two must move together.
         assert_eq!(v["items"][0].as_object().unwrap().len(), 12);
         // Absent ⇒ explicit null, key always present for stable consumers.
         let mut buf = Vec::new();

--- a/src/api/search_report.rs
+++ b/src/api/search_report.rs
@@ -57,6 +57,9 @@ pub struct SearchEntry {
     /// `None` otherwise. Surfaced as a comma-suffixed `deprecated` on the plain
     /// `Status` cell and a dedicated `deprecated` field in JSON.
     pub deprecated: Option<String>,
+    /// The successor reference when the publisher named a replacement; `None`
+    /// otherwise. JSON-only — never shown as its own plain-table column.
+    pub replaced_by: Option<String>,
     /// How the repository relates to the current scope.
     pub status: StatusBadge,
 }
@@ -64,7 +67,7 @@ pub struct SearchEntry {
 impl Serialize for SearchEntry {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         use serde::ser::SerializeStruct;
-        let mut s = serializer.serialize_struct("SearchEntry", 11)?;
+        let mut s = serializer.serialize_struct("SearchEntry", 12)?;
         s.serialize_field("kind", &self.kind)?;
         s.serialize_field("repo", &self.repo)?;
         s.serialize_field("summary", &self.summary)?;
@@ -75,6 +78,7 @@ impl Serialize for SearchEntry {
         s.serialize_field("revision", &self.revision)?;
         s.serialize_field("created", &self.created)?;
         s.serialize_field("deprecated", &self.deprecated)?;
+        s.serialize_field("replaced_by", &self.replaced_by)?;
         s.serialize_field("status", &self.status.to_string())?;
         s.end()
     }
@@ -183,6 +187,7 @@ mod tests {
             latest_tag: Some("latest".to_string()),
             version: None,
             deprecated: None,
+            replaced_by: None,
             status,
         }
     }
@@ -236,6 +241,7 @@ mod tests {
             latest_tag: Some("latest".to_string()),
             version: Some("2.1.0".to_string()),
             deprecated: None,
+            replaced_by: None,
             status: StatusBadge::Installed,
         };
         let mut buf = Vec::new();
@@ -260,6 +266,7 @@ mod tests {
             latest_tag: Some("stable".to_string()),
             version: None,
             deprecated: None,
+            replaced_by: None,
             status: StatusBadge::NotInstalled,
         };
         let mut buf = Vec::new();
@@ -281,6 +288,7 @@ mod tests {
             latest_tag: Some("latest".to_string()),
             version: None,
             deprecated: None,
+            replaced_by: None,
             status: StatusBadge::Installed,
         };
         let mut buf = Vec::new();
@@ -303,6 +311,7 @@ mod tests {
             latest_tag: Some("latest".to_string()),
             version: None,
             deprecated: None,
+            replaced_by: None,
             status: StatusBadge::NotInstalled,
         };
         let mut buf = Vec::new();
@@ -327,6 +336,7 @@ mod tests {
             latest_tag: Some("latest".to_string()),
             version: None,
             deprecated: None,
+            replaced_by: None,
             status: StatusBadge::Installed,
         };
         let mut buf = Vec::new();
@@ -349,6 +359,7 @@ mod tests {
             latest_tag: Some("latest".to_string()),
             version: Some("1.2.0".to_string()),
             deprecated: None,
+            replaced_by: None,
             status: StatusBadge::Installed,
         };
         let mut buf = Vec::new();
@@ -445,6 +456,30 @@ mod tests {
             .unwrap();
         let out = String::from_utf8(buf).unwrap();
         assert!(!out.contains("deprecated"), "non-deprecated row is unmarked");
+    }
+
+    #[test]
+    fn json_carries_replaced_by_plain_table_does_not() {
+        let mut e = entry("localhost:5000/acme/x", StatusBadge::Installed);
+        e.replaced_by = Some("ghcr.io/acme/skills/x2".to_string());
+        let mut buf = Vec::new();
+        SearchReport::new(vec![e.clone()]).print_json(&mut buf).unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&buf).unwrap();
+        assert_eq!(v["items"][0]["replaced_by"], "ghcr.io/acme/skills/x2");
+        // The full 12-field object still round-trips (manual Serialize count).
+        assert_eq!(v["items"][0].as_object().unwrap().len(), 12);
+        // Absent ⇒ explicit null, key always present for stable consumers.
+        let mut buf = Vec::new();
+        SearchReport::new(vec![entry("localhost:5000/acme/y", StatusBadge::Installed)])
+            .print_json(&mut buf)
+            .unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&buf).unwrap();
+        assert!(v["items"][0]["replaced_by"].is_null());
+        // The plain table stays five columns — no replacement leaks into it.
+        let mut buf = Vec::new();
+        SearchReport::new(vec![e]).print_plain(&mut buf).unwrap();
+        let out = String::from_utf8(buf).unwrap();
+        assert!(!out.contains("x2"), "plain table unchanged");
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -115,6 +115,11 @@ pub async fn run(cli: Cli) -> anyhow::Result<ExitCode> {
             render(&r, format)?;
             c
         }
+        Command::Describe(args) => {
+            let (r, c) = crate::command::describe::run(&ctx, &args).await?;
+            render(&r, format)?;
+            c
+        }
         // `schema` prints a JSON Schema document, not a `Printable` report,
         // so it is wired directly like `tui` (subsystem-cli-api.md exemption).
         Command::Schema(args) => crate::command::schema::run(&args)?,

--- a/src/app.rs
+++ b/src/app.rs
@@ -111,7 +111,7 @@ pub async fn run(cli: Cli) -> anyhow::Result<ExitCode> {
             c
         }
         Command::Fetch(args) => {
-            let (r, c) = crate::command::fetch::run(&ctx, &args).await?;
+            let (r, c) = crate::command::fetch::run(&ctx, &args, format).await?;
             render(&r, format)?;
             c
         }

--- a/src/auth/store.rs
+++ b/src/auth/store.rs
@@ -106,6 +106,30 @@ impl DockerCredentialStore {
     pub fn config_path(&self) -> &Path {
         &self.config_path
     }
+
+    /// Whether a credential grim would use when pulling from `registry` is
+    /// present in the docker config, decided **without invoking any
+    /// credential helper** — a single file read, safe to call for every
+    /// registry `grim context` reports.
+    ///
+    /// Mirrors the pull-time lookup in
+    /// [`crate::oci::access::registry_client`]: that path authenticates
+    /// against the registry **host** (`Identifier::registry`, scheme and
+    /// namespace already stripped), so this reduces `registry` to its host
+    /// via [`registry_host`] before canonicalizing to the docker store key.
+    /// Presence is **per-host**: the key must appear in `auths` or
+    /// `credHelpers`. A global `credsStore` with no matching per-host entry
+    /// is deliberately NOT counted — detecting it would mean spawning the
+    /// helper. A missing, unreadable, or malformed config yields `false`,
+    /// never an error: a corrupt `~/.docker/config.json` must not make
+    /// `grim context` fail.
+    pub fn has_credential(&self, registry: &str) -> bool {
+        let canonical = canonicalize_registry(registry_host(registry));
+        match read_config(&self.config_path) {
+            Ok(config) => config.auths.contains_key(&canonical) || config.cred_helpers.contains_key(&canonical),
+            Err(_) => false,
+        }
+    }
 }
 
 #[async_trait]
@@ -279,6 +303,15 @@ struct AuthEntry {
 }
 
 // ── helpers ────────────────────────────────────────────────────────────
+
+/// The host portion of a registry locator: the scheme and any `/namespace`
+/// path stripped, matching what `Identifier::registry` yields at pull time.
+/// `canonicalize_registry` then folds host case / the `docker.io` alias, so
+/// this only has to peel the scheme and the first path segment.
+fn registry_host(registry: &str) -> &str {
+    let after_scheme = registry.split_once("://").map_or(registry, |(_, rest)| rest);
+    after_scheme.split('/').next().unwrap_or(after_scheme)
+}
 
 /// The helper configured for `canonical`: per-registry first, then global.
 fn resolve_helper(config: &DockerConfig, canonical: &str) -> Option<String> {
@@ -541,6 +574,51 @@ mod tests {
         let cred = Credential::basic("u", SecretString::from("p"));
         let res = rt().block_on(store.put("ghcr.io", &cred));
         assert!(matches!(res, Err(AuthError::MalformedConfig { .. })), "got: {res:?}");
+    }
+
+    #[test]
+    fn has_credential_detects_auths_and_cred_helpers_per_host() {
+        let (_d, path) = tmp();
+        std::fs::write(
+            &path,
+            r#"{
+              "auths": {"ghcr.io": {"auth": "dTpw"}},
+              "credHelpers": {"registry.example.com": "ecr-login"},
+              "credsStore": "desktop"
+            }"#,
+        )
+        .unwrap();
+        let store = DockerCredentialStore::with_path(path, opts(false));
+
+        // Present via auths — including when the entry carries a namespace
+        // path the pull path strips off before the host lookup.
+        assert!(store.has_credential("ghcr.io"));
+        assert!(store.has_credential("https://ghcr.io/v2/"));
+        assert!(store.has_credential("ghcr.io/grimoire-rs"));
+        // Present via credHelpers.
+        assert!(store.has_credential("registry.example.com"));
+        // A global credsStore alone is NOT a per-host credential.
+        assert!(!store.has_credential("docker.io"));
+        assert!(!store.has_credential("other.example.com"));
+    }
+
+    #[test]
+    fn has_credential_is_false_for_absent_or_malformed_config() {
+        let (_d, path) = tmp();
+        // Absent file.
+        let store = DockerCredentialStore::with_path(path.clone(), opts(false));
+        assert!(!store.has_credential("ghcr.io"));
+        // Malformed JSON must degrade to false, never panic or error.
+        std::fs::write(&path, "not json {").unwrap();
+        assert!(!store.has_credential("ghcr.io"));
+    }
+
+    #[test]
+    fn registry_host_strips_scheme_and_namespace() {
+        assert_eq!(registry_host("ghcr.io"), "ghcr.io");
+        assert_eq!(registry_host("ghcr.io/grimoire-rs"), "ghcr.io");
+        assert_eq!(registry_host("https://ghcr.io/v2/"), "ghcr.io");
+        assert_eq!(registry_host("localhost:5000/team"), "localhost:5000");
     }
 
     #[test]

--- a/src/catalog/catalog_service.rs
+++ b/src/catalog/catalog_service.rs
@@ -77,6 +77,9 @@ pub struct CatalogRow {
     /// The publisher's deprecation message when the artifact is deprecated;
     /// `None` otherwise. Drives the search / TUI deprecation highlight.
     pub deprecated: Option<String>,
+    /// The successor reference when the publisher named a replacement;
+    /// `None` otherwise. Surfaced in `grim search`.
+    pub replaced_by: Option<String>,
     /// Curated extra `org.opencontainers.image.*` annotations shown in the
     /// TUI detail pane. Empty when the artifact carries none of them.
     pub oci: OciMeta,
@@ -241,6 +244,7 @@ pub async fn load_catalog(
                         revision: e.revision.clone(),
                         created: e.created.clone(),
                         deprecated: e.deprecated.clone(),
+                        replaced_by: e.replaced_by.clone(),
                         oci: e.oci.clone(),
                         latest_tag: e.latest_tag.clone(),
                         version: e.version.clone(),

--- a/src/catalog/index_announce.rs
+++ b/src/catalog/index_announce.rs
@@ -47,6 +47,12 @@ pub struct AnnouncePackage {
     pub description: String,
     /// HTTPS source-repository URL, if known.
     pub repository_url: Option<String>,
+    /// Publisher keywords (`grim search` matches them alongside the
+    /// description). Empty ⇒ omitted from the written pointer.
+    pub keywords: Vec<String>,
+    /// Short single-line blurb (`grim search` matches it too). `None` ⇒
+    /// omitted from the written pointer.
+    pub summary: Option<String>,
 }
 
 /// The announce request: where, as whom, and what.
@@ -319,20 +325,36 @@ fn merge_request_url(push_stderr: &str) -> Option<String> {
         .map(str::to_string)
 }
 
-/// Read the pointer metadata (description + HTTPS source URL) back from
-/// the just-published artifact's manifest annotations: representative tag
-/// → digest → manifest, over the access seam. Every failure degrades to
-/// `None` — announce still proceeds with a fallback description.
+/// Pointer metadata read back from a published artifact's manifest — the
+/// display fields the index carries. Named (not a tuple) so the three
+/// `Option<String>` fields can't be transposed at the call site.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct PointerMetadata {
+    /// `org.opencontainers.image.description`.
+    pub description: Option<String>,
+    /// `org.opencontainers.image.source`, kept only with an `https://` prefix.
+    pub repository_url: Option<String>,
+    /// `com.grimoire.keywords`, comma-split (trimmed, empties dropped).
+    pub keywords: Vec<String>,
+    /// `com.grimoire.summary`.
+    pub summary: Option<String>,
+}
+
+/// Read the pointer metadata (description, HTTPS source URL, keywords,
+/// summary) back from the just-published artifact's manifest annotations:
+/// representative tag → digest → manifest, over the access seam. Every
+/// failure degrades to the default — announce still proceeds with a
+/// fallback description.
 pub async fn pointer_metadata(
     access: &dyn crate::oci::access::OciAccess,
     id: &crate::oci::Identifier,
-) -> (Option<String>, Option<String>) {
+) -> PointerMetadata {
     let tags = match access.list_tags(id).await {
         Ok(Some(tags)) => tags,
-        _ => return (None, None),
+        _ => return PointerMetadata::default(),
     };
     let Some(tag) = crate::catalog::registry_catalog::pick_latest_tag(&tags) else {
-        return (None, None);
+        return PointerMetadata::default();
     };
     let tagged = id.clone_with_tag(tag);
     let digest = match access
@@ -340,25 +362,28 @@ pub async fn pointer_metadata(
         .await
     {
         Ok(Some(d)) => d,
-        _ => return (None, None),
+        _ => return PointerMetadata::default(),
     };
     let Ok(pinned) = crate::oci::PinnedIdentifier::try_from(tagged.clone_with_digest(digest)) else {
-        return (None, None);
+        return PointerMetadata::default();
     };
     let Ok(Some(manifest)) = access.fetch_manifest(&pinned).await else {
-        return (None, None);
+        return PointerMetadata::default();
     };
-    (
-        manifest
+    PointerMetadata {
+        description: manifest
             .annotations
             .get("org.opencontainers.image.description")
             .cloned(),
-        manifest
+        repository_url: manifest
             .annotations
             .get("org.opencontainers.image.source")
             .filter(|s| s.starts_with("https://"))
             .cloned(),
-    )
+        // Same read seam the catalog build and `grim describe` use.
+        keywords: crate::oci::annotations::keywords_from_annotations(&manifest.annotations),
+        summary: manifest.annotations.get("com.grimoire.summary").cloned(),
+    }
 }
 
 /// Render the metadata.json pointer for `pkg` (index spec v1).
@@ -382,6 +407,14 @@ fn metadata_json(pkg: &AnnouncePackage, namespace: &str, owner_id: u64, forge: F
     });
     if let Some(repo) = &pkg.repository_url {
         value["repository"] = serde_json::Value::String(repo.clone());
+    }
+    // Omit-empty: pointers for artifacts without keywords/summary stay
+    // byte-identical to pre-search-metadata index files.
+    if !pkg.keywords.is_empty() {
+        value["keywords"] = serde_json::Value::from(pkg.keywords.clone());
+    }
+    if let Some(summary) = &pkg.summary {
+        value["summary"] = serde_json::Value::String(summary.clone());
     }
     let mut out = serde_json::to_string_pretty(&value).unwrap_or_default();
     out.push('\n');
@@ -471,6 +504,8 @@ mod tests {
             reference: format!("ghcr.io/acme/skills/{name}"),
             description: "A test pointer".to_string(),
             repository_url: Some("https://github.com/acme/skills".to_string()),
+            keywords: Vec::new(),
+            summary: None,
         }
     }
 
@@ -486,7 +521,22 @@ mod tests {
         assert_eq!(value["owner"]["id"], 42);
         assert!(value["owner"].get("login").is_none());
         assert_eq!(value["repository"], "https://github.com/acme/skills");
+        // Omit-empty: a pointer with no keywords/summary carries neither key,
+        // keeping pre-search-metadata index files byte-identical.
+        assert!(value.get("keywords").is_none());
+        assert!(value.get("summary").is_none());
         assert!(rendered.ends_with('\n'), "trailing newline for clean diffs");
+    }
+
+    #[test]
+    fn metadata_json_carries_keywords_and_summary_when_present() {
+        let mut p = pkg("code-review");
+        p.keywords = vec!["review".to_string(), "quality".to_string()];
+        p.summary = Some("Terse review".to_string());
+        let value: serde_json::Value =
+            serde_json::from_str(&metadata_json(&p, "acme", 42, ForgeKind::GitHub)).expect("valid JSON");
+        assert_eq!(value["keywords"], serde_json::json!(["review", "quality"]));
+        assert_eq!(value["summary"], "Terse review");
     }
 
     #[test]

--- a/src/catalog/index_source.rs
+++ b/src/catalog/index_source.rs
@@ -82,6 +82,8 @@ impl IndexPackage {
             revision: None,
             created: None,
             deprecated: None,
+            // The index phone book carries no replacement metadata.
+            replaced_by: None,
             // The index phone book carries no OCI image annotations.
             oci: crate::catalog::registry_catalog::OciMeta::default(),
             // Phone-book contract: no version data in the index; tags are

--- a/src/catalog/index_source.rs
+++ b/src/catalog/index_source.rs
@@ -52,6 +52,15 @@ struct IndexPackage {
     /// Source repository URL.
     #[serde(default)]
     repository: Option<String>,
+    /// Publisher keywords, matched by `grim search` alongside the
+    /// description. Absent in pre-keywords index files (and in the hosted
+    /// `all.json` until packages re-announce) — defaults to `[]`.
+    #[serde(default)]
+    keywords: Vec<String>,
+    /// Short single-line blurb, matched by `grim search`. Absent in
+    /// pre-summary index files — defaults to `None`.
+    #[serde(default)]
+    summary: Option<String>,
 }
 
 impl IndexPackage {
@@ -75,8 +84,8 @@ impl IndexPackage {
             repository: repository.to_string(),
             kind: Some(self.kind),
             description: self.description,
-            summary: None,
-            keywords: Vec::new(),
+            summary: self.summary,
+            keywords: self.keywords,
             // Same HTTPS prefix guard as the manifest read-back path.
             repository_url: self.repository.filter(|r| r.starts_with("https://")),
             revision: None,
@@ -266,6 +275,48 @@ mod tests {
         );
         assert_eq!(e.latest_tag, None, "phone book carries no version data");
         assert_eq!(e.version, None);
+        // Pre-keywords index files carry neither field → defaults.
+        assert!(e.keywords.is_empty(), "missing keywords → []");
+        assert_eq!(e.summary, None, "missing summary → None");
+    }
+
+    #[test]
+    fn package_forwards_keywords_and_summary() {
+        let p = pkg(r#"{
+            "schema": 1,
+            "name": "grim-usage",
+            "kind": "skill",
+            "ref": "ghcr.io/acme/skills/grim-usage",
+            "keywords": ["search", "fetch", " "],
+            "summary": "Drive grim"
+        }"#);
+        let e = p.into_entry("t").expect("maps");
+        // Index keywords are forwarded verbatim (the announce side already
+        // trimmed/dropped empties when writing the pointer). Whitespace-only
+        // entries survive here because JSON arrays are pre-split — the comma
+        // trimming applies only to the manifest annotation string.
+        assert_eq!(e.keywords, vec!["search", "fetch", " "]);
+        assert_eq!(e.summary.as_deref(), Some("Drive grim"));
+    }
+
+    #[test]
+    fn index_entry_matches_keyword_only_query() {
+        use crate::catalog::search_match::SearchQuery;
+        // A term present only in keywords — never in repo, kind, or
+        // description — must match once the index carries the field. This is
+        // the exact gap the fix closes for the default index-backed source.
+        let e = pkg(r#"{
+            "schema": 1,
+            "name": "grim",
+            "kind": "mcp",
+            "ref": "ghcr.io/grimoire-rs/mcp/grim",
+            "description": "The grimoire MCP server",
+            "keywords": ["catalog", "fetch", "render"]
+        }"#)
+        .into_entry("t")
+        .expect("maps");
+        assert!(e.matches(&SearchQuery::parse("fetch")), "keyword-only query matches");
+        assert!(!e.matches(&SearchQuery::parse("absent")), "unrelated term does not");
     }
 
     #[test]

--- a/src/catalog/registry_catalog.rs
+++ b/src/catalog/registry_catalog.rs
@@ -169,6 +169,13 @@ pub struct CatalogEntry {
     /// `None` when not deprecated. Surfaced as the search / TUI highlight.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub deprecated: Option<String>,
+    /// `com.grimoire.replaced-by`, the successor reference when the
+    /// representative tag's manifest names a replacement. `None` otherwise.
+    /// Surfaced in `grim search` and `grim describe`. (Adding this field to
+    /// the `deny_unknown_fields` on-disk shape means an older grim rejects a
+    /// cache a newer grim wrote and rebuilds it — an accepted downgrade.)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub replaced_by: Option<String>,
     /// Curated extra `org.opencontainers.image.*` annotations (licenses,
     /// authors, url, documentation, vendor) surfaced in the TUI detail pane.
     /// Empty when the manifest carried none of them.
@@ -743,6 +750,7 @@ impl Catalog {
             revision: None,
             created: None,
             deprecated: None,
+            replaced_by: None,
             oci: OciMeta::default(),
             latest_tag,
             version,
@@ -814,6 +822,8 @@ impl Catalog {
                 // A non-empty `com.grimoire.deprecated` marks the artifact
                 // deprecated (the single read seam normalizes/trims).
                 let deprecated = crate::oci::annotations::deprecation_message(&m.annotations);
+                // The successor reference, if the publisher named one.
+                let replaced_by = crate::oci::annotations::replacement_ref(&m.annotations);
                 // Curated standard OCI keys (license/authors/url/…) for the
                 // detail pane; absent on artifacts that don't carry them.
                 let oci = OciMeta::from_annotations(&m.annotations);
@@ -828,6 +838,7 @@ impl Catalog {
                     revision,
                     created,
                     deprecated,
+                    replaced_by,
                     oci,
                     latest_tag: Some(tag.clone()),
                     version: version.clone(),
@@ -1036,6 +1047,7 @@ mod tests {
                 revision: Some("abc123def456-dirty".to_string()),
                 created: Some("2026-06-29T12:00:00+00:00".to_string()),
                 deprecated: Some("use acme/code-review-2".to_string()),
+                replaced_by: Some("ghcr.io/acme/skills/code-review-2".to_string()),
                 oci: OciMeta {
                     licenses: Some("Apache-2.0".to_string()),
                     vendor: Some("Acme Inc".to_string()),
@@ -1074,6 +1086,11 @@ mod tests {
             e.deprecated.as_deref(),
             Some("use acme/code-review-2"),
             "deprecation message round-trips through disk"
+        );
+        assert_eq!(
+            e.replaced_by.as_deref(),
+            Some("ghcr.io/acme/skills/code-review-2"),
+            "replacement reference round-trips through disk"
         );
         assert_eq!(
             e.oci.licenses.as_deref(),
@@ -1119,6 +1136,10 @@ mod tests {
         annotations.insert("com.grimoire.keywords".to_string(), kw.to_string());
         annotations.insert("org.opencontainers.image.description".to_string(), desc.to_string());
         annotations.insert("com.grimoire.summary".to_string(), "short summary".to_string());
+        annotations.insert(
+            "com.grimoire.replaced-by".to_string(),
+            "ghcr.io/acme/skills/code-review-2".to_string(),
+        );
         annotations.insert(
             "org.opencontainers.image.source".to_string(),
             "https://github.com/acme/code-review".to_string(),
@@ -1251,6 +1272,11 @@ mod tests {
         assert_eq!(e.kind.as_deref(), Some("skill"));
         assert_eq!(e.description.as_deref(), Some("Review code."));
         assert_eq!(e.summary.as_deref(), Some("short summary"));
+        assert_eq!(
+            e.replaced_by.as_deref(),
+            Some("ghcr.io/acme/skills/code-review-2"),
+            "replacement reference read off the manifest annotation"
+        );
         assert_eq!(e.keywords, vec!["review", "quality"]);
         assert_eq!(
             e.repository_url.as_deref(),
@@ -1824,6 +1850,7 @@ mod tests {
             revision: None,
             created: None,
             deprecated: None,
+            replaced_by: None,
             oci: OciMeta::default(),
             latest_tag: Some("latest".to_string()),
             version: None,

--- a/src/catalog/registry_catalog.rs
+++ b/src/catalog/registry_catalog.rs
@@ -857,27 +857,33 @@ fn split_host_namespace(registry: &str) -> (&str, Option<&str>) {
 /// Pick the representative tag from `tags`: prefer `latest`, else the
 /// highest semver, else the first (lexicographically, for determinism).
 pub fn pick_latest_tag(tags: &[String]) -> Option<String> {
+    // Internal companions (`__grimoire`, …) are never a representative tag,
+    // including the lexicographic fallback below.
+    let tags: Vec<&String> = tags
+        .iter()
+        .filter(|t| !crate::oci::description::is_internal_tag(t))
+        .collect();
     if tags.is_empty() {
         return None;
     }
-    if tags.iter().any(|t| t == "latest") {
+    if tags.iter().any(|t| *t == "latest") {
         return Some("latest".to_string());
     }
     let mut highest: Option<(semver::Version, &String)> = None;
-    for t in tags {
+    for t in &tags {
         // OCI tags normalize `+` → `_`; semver build metadata uses `+`.
         let candidate = t.replace('_', "+");
         if let Ok(v) = semver::Version::parse(&candidate) {
             match &highest {
                 Some((hv, _)) if &v <= hv => {}
-                _ => highest = Some((v, t)),
+                _ => highest = Some((v, *t)),
             }
         }
     }
     if let Some((_, t)) = highest {
         return Some(t.clone());
     }
-    let mut sorted: Vec<&String> = tags.iter().collect();
+    let mut sorted = tags.clone();
     sorted.sort();
     sorted.first().map(|s| (*s).clone())
 }
@@ -995,6 +1001,27 @@ mod tests {
         let tags = vec!["latest".to_string(), "stable".to_string()];
         assert_eq!(pick_highest_version(&tags), None);
         assert_eq!(pick_highest_version(&[]), None);
+    }
+
+    #[test]
+    fn pickers_exclude_internal_desc_tag() {
+        // The `__grimoire` companion tag is never a representative/highest tag,
+        // including the lexicographic fallback (where it would sort first).
+        let only_internal = vec!["__grimoire".to_string()];
+        assert_eq!(
+            pick_latest_tag(&only_internal),
+            None,
+            "internal-only ⇒ no representative"
+        );
+        assert_eq!(pick_highest_version(&only_internal), None);
+
+        let mixed = vec!["__grimoire".to_string(), "1.2.0".to_string()];
+        assert_eq!(pick_latest_tag(&mixed), Some("1.2.0".to_string()));
+        assert_eq!(pick_highest_version(&mixed), Some("1.2.0".to_string()));
+
+        // No semver, no latest: the fallback must still skip the internal tag.
+        let internal_and_other = vec!["__grimoire".to_string(), "nightly".to_string()];
+        assert_eq!(pick_latest_tag(&internal_and_other), Some("nightly".to_string()));
     }
 
     // ── TTL freshness ────────────────────────────────────────────────

--- a/src/catalog/registry_catalog.rs
+++ b/src/catalog/registry_catalog.rs
@@ -797,17 +797,7 @@ impl Catalog {
                 let kind = crate::oci::annotations::kind_from_manifest(&m).map(|k| k.to_string());
                 let description = m.annotations.get("org.opencontainers.image.description").cloned();
                 let summary = m.annotations.get("com.grimoire.summary").cloned();
-                let keywords = m
-                    .annotations
-                    .get("com.grimoire.keywords")
-                    .map(|k| {
-                        k.split(',')
-                            .map(str::trim)
-                            .filter(|s| !s.is_empty())
-                            .map(str::to_string)
-                            .collect::<Vec<_>>()
-                    })
-                    .unwrap_or_default();
+                let keywords = crate::oci::annotations::keywords_from_annotations(&m.annotations);
                 // Pre-repository artifacts carry the release ref here —
                 // the prefix guard keeps only real HTTPS repo URLs.
                 let repository_url = m

--- a/src/command.rs
+++ b/src/command.rs
@@ -13,6 +13,7 @@ pub mod build;
 pub mod command_error;
 pub mod config;
 pub mod context;
+pub mod describe;
 pub mod fetch;
 pub mod init;
 pub mod install;

--- a/src/command/build.rs
+++ b/src/command/build.rs
@@ -112,6 +112,7 @@ pub fn validate_and_pack(
                 tracing::warn!("{}: {warning}", path.display());
             }
             validate_repository(path, fm.metadata.get("repository").map(String::as_str))?;
+            validate_replaced_by(path, fm.metadata.get("replaced-by").map(String::as_str))?;
             let tar = super::grim(pack_skill_dir(path))?;
             let annotations = annotations_for_skill(&fm, version, fallback_source, git);
             Ok(PackedArtifact {
@@ -150,6 +151,10 @@ pub fn validate_and_pack(
                 path,
                 crate::oci::annotations::string_from_extra(&fm, "repository").as_deref(),
             )?;
+            validate_replaced_by(
+                path,
+                crate::oci::annotations::string_from_extra(&fm, "replaced-by").as_deref(),
+            )?;
             let tar = super::grim(pack_rule_file(path))?;
             let annotations = annotations_for_rule(&name, &fm, &parsed.body, version, fallback_source, git);
             Ok(PackedArtifact {
@@ -168,6 +173,7 @@ pub fn validate_and_pack(
                 tracing::warn!("{}: {warning}", path.display());
             }
             validate_repository(path, fm.metadata.get("repository").map(String::as_str))?;
+            validate_replaced_by(path, fm.metadata.get("replaced-by").map(String::as_str))?;
             let tar = super::grim(pack_agent_file(path))?;
             let annotations = annotations_for_agent(&fm, version, fallback_source, git);
             Ok(PackedArtifact {
@@ -211,6 +217,21 @@ where
 fn validate_repository(path: &Path, repository: Option<&str>) -> anyhow::Result<()> {
     if let Some(url) = repository {
         super::grim(crate::oci::annotations::validate_repository_url(url).map_err(metadata_invalid(path)))?;
+    }
+    Ok(())
+}
+
+/// Publish-time gate for an authored `replaced-by` metadata value: present
+/// but not a parseable artifact reference ⇒ path-attributed DataError (65).
+/// Absent or whitespace-only ⇒ Ok. Mirrors [`validate_repository`] so a bad
+/// successor reference can never reach a registry.
+fn validate_replaced_by(path: &Path, replaced_by: Option<&str>) -> anyhow::Result<()> {
+    if let Some(value) = replaced_by.map(str::trim).filter(|v| !v.is_empty()) {
+        super::grim(
+            crate::oci::Identifier::parse(value)
+                .map(|_| ())
+                .map_err(metadata_invalid(path)),
+        )?;
     }
     Ok(())
 }
@@ -278,8 +299,10 @@ pub fn read_bundle_members(
     }
     let source = super::grim(crate::config::project_config::BundleSource::from_toml_str(&content))?;
     // Same publish-time gate as skills/rules/agents: a non-HTTPS authored
-    // repository hard-fails before anything can reach a registry.
+    // repository (and an unparseable `replaced-by`) hard-fail before
+    // anything can reach a registry.
     validate_repository(path, source.metadata.repository.as_deref())?;
+    validate_replaced_by(path, source.metadata.replaced_by.as_deref())?;
 
     let mut members = Vec::new();
     for (name, id) in &source.skills {
@@ -528,6 +551,44 @@ mod tests {
             packed.annotations["org.opencontainers.image.source"],
             "https://github.com/acme/s"
         );
+    }
+
+    #[test]
+    fn validate_and_pack_rejects_unparseable_replaced_by() {
+        // A `replaced-by` value that does not parse as an artifact reference
+        // hard-fails the build (65) before anything reaches a registry.
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("s");
+        write(
+            &dir.join("SKILL.md"),
+            "---\nname: s\ndescription: d\nmetadata:\n  replaced-by: \"not a valid ref\"\n---\n",
+        );
+        let err = validate_and_pack(&dir, ArtifactKind::Skill, "1.0.0", None, None).unwrap_err();
+        assert_eq!(crate::error::classify_error(&err), ExitCode::DataError);
+
+        // A well-formed fully-qualified reference is accepted and emitted.
+        let ok = tmp.path().join("s2");
+        write(
+            &ok.join("SKILL.md"),
+            "---\nname: s2\ndescription: d\nmetadata:\n  replaced-by: ghcr.io/acme/skills/s3\n---\n",
+        );
+        let packed = validate_and_pack(&ok, ArtifactKind::Skill, "1.0.0", None, None).unwrap();
+        assert_eq!(
+            packed.annotations[crate::oci::annotations::REPLACED_BY_ANNOTATION],
+            "ghcr.io/acme/skills/s3"
+        );
+    }
+
+    #[test]
+    fn read_bundle_members_rejects_unparseable_replaced_by() {
+        let tmp = tempfile::tempdir().unwrap();
+        let f = tmp.path().join("stack.toml");
+        write(
+            &f,
+            "replaced-by = \"not a valid ref\"\n\n[skills]\ncr = \"ghcr.io/acme/cr:1\"\n",
+        );
+        let err = read_bundle_members(&f).unwrap_err();
+        assert_eq!(crate::error::classify_error(&err), ExitCode::DataError);
     }
 
     #[test]

--- a/src/command/context.rs
+++ b/src/command/context.rs
@@ -17,6 +17,7 @@
 use clap::Args;
 
 use crate::api::context_report::{ContextRegistry, ContextRegistryKind, ContextReport, OfflineSource};
+use crate::auth::store::{DockerCredentialStore, StoreOptions};
 use crate::cli::exit_code::ExitCode;
 use crate::context::Context;
 use crate::install::target::InstallTarget;
@@ -46,9 +47,15 @@ pub async fn run(ctx: &Context, _args: &ContextArgs) -> anyhow::Result<(ContextR
     ))?;
     let clients = target.clients().iter().map(ToString::to_string).collect();
 
+    // A file-only view of the docker-compatible credential store, resolved
+    // once. `None` when no config location exists (no `$DOCKER_CONFIG`, no
+    // home) — everything then reports `authenticated: false`. Never spawns a
+    // credential helper.
+    let cred_store = DockerCredentialStore::new(StoreOptions::default()).ok();
     let registries = super::registries_for_scope(ctx, &scope)
         .into_iter()
         .map(|r| ContextRegistry {
+            authenticated: cred_store.as_ref().is_some_and(|s| s.has_credential(&r.url)),
             alias: r.alias,
             kind: if r.kind.is_index() {
                 ContextRegistryKind::Index

--- a/src/command/describe.rs
+++ b/src/command/describe.rs
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The Grimoire Authors
+
+//! `grim describe <ref>` — report an artifact's manifest-level metadata
+//! (kind, curated annotations, tags) without downloading its content.
+//!
+//! CLI port of the MCP `grim_describe` tool, sharing the neutral describe
+//! core ([`crate::fetch::describe_artifact`]): it resolves the reference,
+//! lists the repository's tags, and reads the manifest annotations — no blob
+//! is ever pulled. Plain mode prints a flat key/value table (like
+//! `grim context`); `--format json` emits the full describe report.
+//!
+//! Non-fatal warnings (a degraded scope falling back to the flag/env/global
+//! registry chain) go to stderr via `tracing` so the stdout payload stays
+//! clean.
+
+use clap::Args;
+
+use crate::api::describe_report::DescribeCliReport;
+use crate::cli::exit_code::ExitCode;
+use crate::context::Context;
+
+/// `grim describe` arguments.
+#[derive(Debug, Args)]
+pub struct DescribeArgs {
+    /// The artifact reference: a short id (`skills/code-review`), an
+    /// alias-qualified ref, or a fully qualified one. Defaults to `latest`
+    /// when no tag/digest is given.
+    pub reference: String,
+}
+
+/// Run `grim describe`.
+///
+/// # Errors
+///
+/// Reference/resolution/transport failures (their own exit taxonomy: offline
+/// 81, auth 80, unreachable 69, …) or a missing tag / manifest.
+pub async fn run(ctx: &Context, args: &DescribeArgs) -> anyhow::Result<(DescribeCliReport, ExitCode)> {
+    let scope = crate::command::resolve_fetch_scope(ctx, ctx.global(), ctx.config(), None);
+    // Degraded-scope warnings ride stderr so stdout stays a pure report.
+    for warning in &scope.warnings {
+        tracing::warn!("{warning}");
+    }
+    let access = crate::command::access_seam(ctx)?;
+    let report = crate::fetch::describe_artifact(&scope, &access, &args.reference).await?;
+    Ok((DescribeCliReport(report), ExitCode::Success))
+}

--- a/src/command/fetch.rs
+++ b/src/command/fetch.rs
@@ -16,10 +16,13 @@
 //! prints byte-complete. Non-fatal warnings go to stderr via `tracing` so
 //! the stdout payload stays clean.
 
+use std::path::PathBuf;
+
 use clap::Args;
 
 use crate::api::fetch_report::FetchCliReport;
 use crate::cli::exit_code::ExitCode;
+use crate::cli::options::OutputFormat;
 use crate::context::Context;
 use crate::fetch::FETCH_BLOB_SIZE_LIMIT;
 
@@ -40,35 +43,73 @@ pub struct FetchArgs {
     /// listing) instead of the index document. UTF-8 text only.
     #[arg(long)]
     pub path: Option<String>,
+
+    /// Fetch the repository description companion (README, logo, CHANGELOG)
+    /// instead of the artifact. JSON returns every member inline; plain
+    /// requires `--out`.
+    #[arg(long)]
+    pub description: bool,
+
+    /// Resolve the reference to a digest and report `{ref, digest}` without
+    /// downloading the manifest or any blob — a cheap cache probe. Composes
+    /// with `--description` to probe the companion tag.
+    #[arg(long)]
+    pub digest_only: bool,
+
+    /// Unpack the `--description` companion tree into this directory (created
+    /// if absent). Only valid with `--description`.
+    #[arg(long)]
+    pub out: Option<PathBuf>,
 }
 
 /// Run `grim fetch`.
 ///
 /// # Errors
 ///
-/// Reference/resolution/transport failures (their own exit taxonomy), an
-/// unknown `--vendor`, a `--vendor` on a bundle, a missing `--path`
-/// entry, an oversize layer, or non-UTF-8 content.
-pub async fn run(ctx: &Context, args: &FetchArgs) -> anyhow::Result<(FetchCliReport, ExitCode)> {
+/// A flag-combination usage error (64), reference/resolution/transport
+/// failures (their own exit taxonomy), an unknown `--vendor`, a `--vendor`
+/// on a bundle, a missing `--path` / companion, an oversize layer, or
+/// non-UTF-8 content.
+pub async fn run(ctx: &Context, args: &FetchArgs, format: OutputFormat) -> anyhow::Result<(FetchCliReport, ExitCode)> {
+    // Flag-combination usage gates (exit 64) before any resolution.
+    if args.out.is_some() && !args.description {
+        return Err(crate::command::config_usage("--out is only valid with --description"));
+    }
+    if args.digest_only && (args.vendor.is_some() || args.path.is_some() || args.out.is_some()) {
+        return Err(crate::command::config_usage(
+            "--digest-only resolves a digest without downloading; it takes no --vendor, --path, or --out",
+        ));
+    }
+    // The full companion bundle has no single plain payload. A `--path` member
+    // does (it prints like any support file), so only the bundle is gated.
+    if args.description && args.path.is_none() && args.out.is_none() && matches!(format, OutputFormat::Plain) {
+        return Err(crate::command::config_usage(
+            "--description prints a multi-file bundle with no single plain payload; pass --out <dir> or --format json",
+        ));
+    }
+
     let scope = crate::command::resolve_fetch_scope(ctx, ctx.global(), ctx.config(), None);
     let access = crate::command::access_seam(ctx)?;
-    // The layer gate (8 MiB, pre-download) is the effective ceiling, so
-    // with the same value as the doc cap truncation is unreachable and
-    // the plain payload pipes byte-complete.
-    let report = crate::fetch::fetch_with_limit(
+    // The layer gate (8 MiB, pre-download) is the effective ceiling, so with
+    // the same value as the doc cap, truncation is unreachable and the plain
+    // payload pipes byte-complete.
+    let outcome = crate::fetch::fetch_outcome(
         &scope,
         &access,
         &args.reference,
         args.vendor.as_deref(),
         args.path.as_deref(),
+        args.description,
+        args.digest_only,
+        args.out.as_deref(),
         FETCH_BLOB_SIZE_LIMIT as usize,
     )
     .await?;
 
     // Warnings ride stderr so stdout stays a pure payload.
-    for warning in &report.warnings {
+    for warning in outcome.warnings() {
         tracing::warn!("{warning}");
     }
 
-    Ok((FetchCliReport(report), ExitCode::Success))
+    Ok((FetchCliReport(outcome), ExitCode::Success))
 }

--- a/src/command/publish.rs
+++ b/src/command/publish.rs
@@ -19,8 +19,8 @@
 //! every entry uniformly, with no cascade. A channel obeys the same
 //! skip-existing / `--force` rule as everything else.
 
-use std::collections::BTreeMap;
-use std::path::PathBuf;
+use std::collections::{BTreeMap, HashSet};
+use std::path::{Path, PathBuf};
 
 use clap::Args;
 use schemars::JsonSchema;
@@ -145,6 +145,53 @@ pub struct AnnounceSpec {
     pub owner_id: Option<u64>,
 }
 
+/// A repository description companion source (`[description]` table, top-level
+/// or per-entry). All paths are relative to the manifest (`publish.toml`).
+///
+/// Well-known members map their source path onto a fixed on-wire name so the
+/// repository layout is decoupled from the companion layout: `readme` →
+/// `README.md`, `logo` → `logo.<ext>` (`logo.png` / `logo.svg`), `changelog` →
+/// `CHANGELOG.md`. `include` globs (README-referenced assets) keep their
+/// manifest-relative path on the wire. Every member is optional, but a table
+/// that resolves to zero files is a data error (there is nothing to publish).
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct DescriptionSpec {
+    /// The repo's human-facing README, packed as the well-known `README.md`.
+    pub readme: Option<PathBuf>,
+
+    /// The repo's logo, packed as `logo.<ext>` (well-known `logo.png` /
+    /// `logo.svg` by source extension).
+    pub logo: Option<PathBuf>,
+
+    /// The repo's changelog, packed as the well-known `CHANGELOG.md`.
+    pub changelog: Option<PathBuf>,
+
+    /// Extra asset globs (README-referenced images). Each glob is relative to
+    /// the manifest directory; hits keep their relative path on the wire.
+    /// Supports `*`/`?` within a path segment and `**` across segments.
+    #[serde(default)]
+    pub include: Vec<String>,
+
+    /// Top-level kill switch: `publish = false` disables the auto-companion for
+    /// the whole manifest. Ignored on a per-entry table (opt out an entry with
+    /// `description = false` instead).
+    pub publish: Option<bool>,
+}
+
+/// A per-entry `description` in a kind sub-table: either a bool
+/// (`description = false` opts the entry out of the fan-out; `true` is an
+/// explicit opt-in, same as omitting) or a full override table sharing the
+/// [`DescriptionSpec`] schema.
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(untagged)]
+pub enum EntryDescription {
+    /// `description = false` (opt out) or `description = true` (explicit opt in).
+    Enabled(bool),
+    /// A per-entry override table, replacing the top-level companion.
+    Spec(DescriptionSpec),
+}
+
 /// A single entry in a kind table (`[skills.name]`, `[rules.name]`,
 /// `[agents.name]`, `[bundles.name]`).
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -175,6 +222,12 @@ pub struct PublishEntrySpec {
     /// A `pin = true` on a non-bundle entry is a data error (exit 65).
     #[serde(default)]
     pub pin: bool,
+
+    /// Per-entry description companion: `false` opts this entry out of the
+    /// top-level `[description]` fan-out; a `[<kind>.<name>.description]` table
+    /// overrides it with the entry's own [`DescriptionSpec`]. Absent = inherit
+    /// the top-level companion (or the conventional probe).
+    pub description: Option<EntryDescription>,
 }
 
 /// The deserialized content of a `publish.toml` manifest.
@@ -235,6 +288,15 @@ pub struct PublishManifest {
     /// namespace, owner id).
     #[serde(default)]
     pub announce: Option<AnnounceSpec>,
+
+    /// The repository description companion published to every entry
+    /// (fan-out). A per-entry `description` overrides it; `description = false`
+    /// opts an entry out; `publish = false` here is the manifest-wide kill
+    /// switch. When this table is absent grim probes the manifest directory for
+    /// conventional files (`README.md`, `CHANGELOG.md`, `assets/logo.*`,
+    /// `logo.*`) and publishes a companion when any is found.
+    #[serde(default)]
+    pub description: Option<DescriptionSpec>,
 }
 
 /// One planned publish operation, ready to be handed to `release::run`.
@@ -255,6 +317,18 @@ pub(crate) struct PlannedEntry {
     /// appended. Drives a `--dry-run`-only preview hint so a user who expected
     /// `repository_prefix` append-semantics notices the difference.
     pub name_not_appended: bool,
+}
+
+/// One planned description companion push, deduplicated to a distinct target
+/// repository. The companion re-points that repository's reserved `__grimoire`
+/// tag at the packed [`files`](Self::files) mapping.
+#[derive(Debug)]
+pub(crate) struct PlannedDescription {
+    /// The target repository (`registry/repo`, no tag) the companion publishes
+    /// to (the reserved `__grimoire` tag is appended at push time).
+    pub repository: String,
+    /// The resolved `(packed_name, absolute_source_path)` mapping, non-empty.
+    pub files: Vec<(String, PathBuf)>,
 }
 
 /// Strict `X.Y.Z` semver check: no prerelease, no build metadata, no
@@ -637,6 +711,11 @@ pub async fn run(ctx: &Context, args: &PublishArgs) -> anyhow::Result<(PublishRe
         channel,
     );
 
+    // Resolve the description companions before any push: an explicit companion
+    // path that does not exist is a data error (65) surfaced here, not partway
+    // through the batch. Conventional-probe misses stay silent.
+    let planned_descriptions = plan_descriptions(&manifest, &entries, &manifest_dir, &args.manifest)?;
+
     // Dry-run preview only: flag entries whose per-entry `repository` is used
     // verbatim and does not end in the entry name (the name was not appended).
     // Surfaced here — not as a publish-time warning — so a real publish of a
@@ -651,6 +730,14 @@ pub async fn run(ctx: &Context, args: &PublishArgs) -> anyhow::Result<(PublishRe
                     planned.reference,
                 );
             }
+        }
+        for pd in &planned_descriptions {
+            tracing::info!(
+                "description: would publish {}:{} ({} file(s))",
+                pd.repository,
+                crate::oci::description::DESC_TAG,
+                pd.files.len(),
+            );
         }
     }
 
@@ -721,6 +808,44 @@ pub async fn run(ctx: &Context, args: &PublishArgs) -> anyhow::Result<(PublishRe
         }
     }
 
+    // Description companions ride the batch: after every entry's artifact is
+    // live, (re)point each distinct repository's reserved `__grimoire` tag at
+    // its resolved companion. Mutable metadata — always re-pointed, never gated
+    // by skip-existing; deterministic packing makes an unchanged republish a
+    // CAS no-op. Under `--dry-run` nothing is pushed, the digest is omitted.
+    let mut description_items: Vec<crate::api::publish_report::PublishDescription> = Vec::new();
+    for pd in &planned_descriptions {
+        let reference = format!("{}:{}", pd.repository, crate::oci::description::DESC_TAG);
+        let files: Vec<String> = pd.files.iter().map(|(name, _)| name.clone()).collect();
+        if args.dry_run {
+            description_items.push(crate::api::publish_report::PublishDescription {
+                reference,
+                repository: pd.repository.clone(),
+                digest: None,
+                files,
+            });
+            continue;
+        }
+        match push_one_description(ctx, pd).await {
+            Ok(digest) => {
+                eprintln!("description: published {reference}");
+                description_items.push(crate::api::publish_report::PublishDescription {
+                    reference,
+                    repository: pd.repository.clone(),
+                    digest: Some(digest.to_string()),
+                    files,
+                });
+            }
+            Err(err) => {
+                // The entries are live; surface the companion failure and keep
+                // the report (with whatever companions already pushed).
+                eprintln!("error: description companion push failed: {err:#}");
+                let report = PublishReport::new(report_entries).with_descriptions(description_items);
+                return Ok((report, classify_error(&err)));
+            }
+        }
+    }
+
     // Announce only after a fully successful, non-dry-run publish: every
     // planned entry is now live on the registry (freshly pushed or already
     // present via skip-existing).
@@ -737,16 +862,48 @@ pub async fn run(ctx: &Context, args: &PublishArgs) -> anyhow::Result<(PublishRe
                     // failures exit Unavailable (69), announce misconfiguration
                     // (missing host/namespace/owner id) exits usage (64).
                     eprintln!("error: announce failed: {err:#}");
-                    return Ok((PublishReport::new(report_entries), classify_error(&err)));
+                    return Ok((
+                        PublishReport::new(report_entries).with_descriptions(description_items),
+                        classify_error(&err),
+                    ));
                 }
             }
         }
     }
 
     Ok((
-        PublishReport::new(report_entries).with_announce(announce_section),
+        PublishReport::new(report_entries)
+            .with_descriptions(description_items)
+            .with_announce(announce_section),
         ExitCode::Success,
     ))
+}
+
+/// Pack and push one planned description companion, returning the pushed
+/// manifest digest. Packs the resolved file mapping on the blocking pool (it is
+/// `std::fs` I/O, mirroring [`crate::skill::pack_local_artifact_blocking`]),
+/// then hands the tar to [`crate::oci::description::push_description_companion`].
+///
+/// # Errors
+///
+/// A pack failure (65/74) or a registry/auth failure (69/80) propagates via
+/// the typed error chain.
+async fn push_one_description(ctx: &Context, pd: &PlannedDescription) -> anyhow::Result<crate::oci::Digest> {
+    let files = pd.files.clone();
+    #[allow(clippy::expect_used)]
+    let tar = super::grim(
+        tokio::task::spawn_blocking(move || crate::skill::pack_description_files(&files))
+            .await
+            .expect("description pack task panicked"),
+    )?;
+    let id = super::grim(crate::oci::Identifier::parse(&format!(
+        "{}:{}",
+        pd.repository,
+        crate::oci::description::DESC_TAG
+    )))?;
+    let repo = id.without_tag();
+    let access = super::access_seam(ctx)?;
+    super::grim(crate::oci::description::push_description_companion(access.as_ref(), &repo, &tar).await)
 }
 
 /// Execute the `--announce` step: derive one metadata pointer per planned
@@ -1350,6 +1507,315 @@ fn plan_entries(
     entries
 }
 
+/// The well-known on-wire name for a companion README.
+const DESC_README: &str = "README.md";
+
+/// The well-known on-wire name for a companion changelog.
+const DESC_CHANGELOG: &str = "CHANGELOG.md";
+
+/// Resolve the description companions to publish for this run — one per
+/// distinct target repository.
+///
+/// Fan-out: the top-level `[description]` (or, when it is absent, the
+/// conventional probe) applies to every planned entry; a per-entry
+/// `description` table overrides it, and `description = false` opts an entry
+/// out. Explicit spec paths that do not exist are a data error (65) so a
+/// misconfiguration fails before any push; conventional-probe misses are
+/// silent (no companion, not an error). The result is deduplicated by target
+/// repository, in entry order.
+///
+/// `entries` is the already-`--only`-filtered planned set, so a companion is
+/// only planned for a repository this run actually touches.
+///
+/// # Errors
+///
+/// Data error (65) when an explicit `readme`/`logo`/`changelog` path is
+/// missing, or when an explicit `[description]` table resolves to no files.
+fn plan_descriptions(
+    manifest: &PublishManifest,
+    entries: &[PlannedEntry],
+    manifest_dir: &Path,
+    manifest_path: &Path,
+) -> anyhow::Result<Vec<PlannedDescription>> {
+    // The top-level fallback, resolved once. `publish = false` is the
+    // manifest-wide kill switch; with no `[description]` table grim probes the
+    // conventional files.
+    let top_level: Option<Vec<(String, PathBuf)>> = match &manifest.description {
+        Some(spec) if spec.publish == Some(false) => None,
+        Some(spec) => Some(resolve_description_spec(spec, manifest_dir, manifest_path)?),
+        None => {
+            let probed = probe_conventional_description(manifest_dir);
+            (!probed.is_empty()).then_some(probed)
+        }
+    };
+
+    let mut planned: Vec<PlannedDescription> = Vec::new();
+    let mut seen: HashSet<String> = HashSet::new();
+    for entry in entries {
+        let files = match entry_description(manifest, entry.kind, &entry.name) {
+            Some(EntryDescription::Enabled(false)) => None,
+            Some(EntryDescription::Enabled(true)) => top_level.clone(),
+            Some(EntryDescription::Spec(spec)) => Some(resolve_description_spec(spec, manifest_dir, manifest_path)?),
+            None => top_level.clone(),
+        };
+        let Some(files) = files else { continue };
+        // The repository is the entry reference minus its tag. The rightmost
+        // `:` is the tag separator (a registry port keeps its own earlier `:`).
+        let repository = entry
+            .reference
+            .rsplit_once(':')
+            .map(|(repo, _)| repo.to_string())
+            .unwrap_or_else(|| entry.reference.clone());
+        if seen.insert(repository.clone()) {
+            planned.push(PlannedDescription { repository, files });
+        }
+    }
+    Ok(planned)
+}
+
+/// The per-entry `description` override for `(kind, name)`, if any.
+fn entry_description<'a>(
+    manifest: &'a PublishManifest,
+    kind: ArtifactKind,
+    name: &str,
+) -> Option<&'a EntryDescription> {
+    let table = match kind {
+        ArtifactKind::Skill => &manifest.skills,
+        ArtifactKind::Rule => &manifest.rules,
+        ArtifactKind::Agent => &manifest.agents,
+        ArtifactKind::Bundle => &manifest.bundles,
+        ArtifactKind::Mcp => &manifest.mcp,
+    };
+    table.get(name).and_then(|s| s.description.as_ref())
+}
+
+/// Resolve a [`DescriptionSpec`] into a sorted, deduplicated
+/// `(packed_name, absolute_source_path)` mapping. Well-known members map onto
+/// their fixed wire names; `include` globs keep their manifest-relative path.
+/// Well-known members win over an `include` glob that also matched them.
+///
+/// # Errors
+///
+/// Data error (65) when an explicit `readme`/`logo`/`changelog` path is
+/// missing, or when the whole spec resolves to no files.
+fn resolve_description_spec(
+    spec: &DescriptionSpec,
+    manifest_dir: &Path,
+    manifest_path: &Path,
+) -> anyhow::Result<Vec<(String, PathBuf)>> {
+    let mut files: Vec<(String, PathBuf)> = Vec::new();
+
+    if let Some(readme) = &spec.readme {
+        files.push((
+            DESC_README.to_string(),
+            require_desc_path(readme, "readme", manifest_dir, manifest_path)?,
+        ));
+    }
+    if let Some(logo) = &spec.logo {
+        let src = require_desc_path(logo, "logo", manifest_dir, manifest_path)?;
+        files.push((logo_packed_name(logo), src));
+    }
+    if let Some(changelog) = &spec.changelog {
+        files.push((
+            DESC_CHANGELOG.to_string(),
+            require_desc_path(changelog, "changelog", manifest_dir, manifest_path)?,
+        ));
+    }
+    // Include globs contribute assets that keep their relative path. A glob
+    // that matches nothing is silent (unlike a named path): it names a set,
+    // not a specific file. The final empty-set check still catches a wholly
+    // empty spec.
+    for pattern in &spec.include {
+        for hit in expand_description_glob(manifest_dir, pattern) {
+            files.push(hit);
+        }
+    }
+
+    // Dedup by packed name, first occurrence wins (well-known members precede
+    // include hits), then sort for a deterministic layer.
+    let mut seen: HashSet<String> = HashSet::new();
+    files.retain(|(name, _)| seen.insert(name.clone()));
+    files.sort_by(|a, b| a.0.cmp(&b.0));
+
+    if files.is_empty() {
+        return Err(data_error_at(
+            manifest_path,
+            "[description] resolves to no files; set readme/logo/changelog/include or remove the table",
+        ));
+    }
+    Ok(files)
+}
+
+/// Join `rel` onto the manifest directory and require the result to be an
+/// existing file — an explicit companion path must not silently skip.
+///
+/// # Errors
+///
+/// Data error (65) when the joined path is not an existing file.
+fn require_desc_path(rel: &Path, field: &str, manifest_dir: &Path, manifest_path: &Path) -> anyhow::Result<PathBuf> {
+    let src = manifest_dir.join(rel);
+    if !src.is_file() {
+        return Err(data_error_at(
+            manifest_path,
+            format!(
+                "description {field} '{}' does not exist (paths are relative to the manifest)",
+                rel.display()
+            ),
+        ));
+    }
+    Ok(src)
+}
+
+/// The on-wire packed name for a logo source: `logo.<ext>` (the well-known
+/// `logo.png` / `logo.svg`), lower-cased; bare `logo` when the source has no
+/// extension.
+fn logo_packed_name(path: &Path) -> String {
+    match path.extension().and_then(|e| e.to_str()) {
+        Some(ext) => format!("logo.{}", ext.to_ascii_lowercase()),
+        None => "logo".to_string(),
+    }
+}
+
+/// Probe the manifest directory for the conventional description files, used
+/// when no `[description]` table is authored. Returns the well-known-name
+/// mapping (sorted); an empty result means no companion. All misses are silent.
+fn probe_conventional_description(manifest_dir: &Path) -> Vec<(String, PathBuf)> {
+    let mut files: Vec<(String, PathBuf)> = Vec::new();
+
+    let readme = manifest_dir.join("README.md");
+    if readme.is_file() {
+        files.push((DESC_README.to_string(), readme));
+    }
+    let changelog = manifest_dir.join("CHANGELOG.md");
+    if changelog.is_file() {
+        files.push((DESC_CHANGELOG.to_string(), changelog));
+    }
+    // A repo has one logo; the first hit wins. Probe order: assets/ before the
+    // repo root, png before svg.
+    for candidate in ["assets/logo.png", "assets/logo.svg", "logo.png", "logo.svg"] {
+        let p = manifest_dir.join(candidate);
+        if p.is_file() {
+            files.push((logo_packed_name(&p), p));
+            break;
+        }
+    }
+    files.sort_by(|a, b| a.0.cmp(&b.0));
+    files
+}
+
+/// Recursion depth cap for `**` glob expansion — a stack guard against a
+/// symlink loop in the (trusted-but-not-necessarily-benign) manifest tree.
+const GLOB_DEPTH_LIMIT: usize = 64;
+
+/// Expand an `include` glob (relative to the manifest directory) into
+/// `(packed_name, absolute_path)` pairs. The packed name is the file's
+/// manifest-relative forward-slash path, so a hit keeps its layout on the
+/// wire. Supports `*`/`?` within a path segment and `**` across segments; the
+/// walk only descends directories matching a preceding segment, so it never
+/// walks the whole tree.
+fn expand_description_glob(manifest_dir: &Path, pattern: &str) -> Vec<(String, PathBuf)> {
+    let segments: Vec<&str> = pattern.split('/').filter(|s| !s.is_empty()).collect();
+    let mut hits: Vec<PathBuf> = Vec::new();
+    glob_segments(manifest_dir, &segments, 0, &mut hits);
+    hits.into_iter()
+        .filter_map(|abs| {
+            let rel = abs.strip_prefix(manifest_dir).ok()?;
+            let packed: Vec<String> = rel
+                .components()
+                .filter_map(|c| match c {
+                    std::path::Component::Normal(s) => Some(s.to_string_lossy().into_owned()),
+                    _ => None,
+                })
+                .collect();
+            (!packed.is_empty()).then(|| (packed.join("/"), abs))
+        })
+        .collect()
+}
+
+/// Recursively match `segments` against the tree rooted at `dir`, pushing every
+/// matching **file** into `out`. `**` matches zero or more path segments.
+fn glob_segments(dir: &Path, segments: &[&str], depth: usize, out: &mut Vec<PathBuf>) {
+    if depth > GLOB_DEPTH_LIMIT {
+        return;
+    }
+    let Some((seg, rest)) = segments.split_first() else {
+        // No more segments: `dir` is a terminal match if it is a file.
+        if dir.is_file() {
+            out.push(dir.to_path_buf());
+        }
+        return;
+    };
+    if *seg == "**" {
+        // `**` matches zero segments (try the rest here) …
+        glob_segments(dir, rest, depth + 1, out);
+        // … or one-or-more (recurse into each subdirectory, `**` retained).
+        for child in read_dir_sorted(dir) {
+            if child.is_dir() {
+                glob_segments(&child, segments, depth + 1, out);
+            }
+        }
+        return;
+    }
+    if seg.contains('*') || seg.contains('?') {
+        for child in read_dir_sorted(dir) {
+            if let Some(name) = child.file_name().and_then(|n| n.to_str())
+                && wildcard_match(seg, name)
+            {
+                glob_segments(&child, rest, depth + 1, out);
+            }
+        }
+        return;
+    }
+    // Literal segment.
+    let next = dir.join(seg);
+    if next.exists() {
+        glob_segments(&next, rest, depth + 1, out);
+    }
+}
+
+/// Read `dir`'s immediate children, sorted, for a deterministic glob walk.
+/// A read failure yields no children (a missing directory contributes nothing).
+fn read_dir_sorted(dir: &Path) -> Vec<PathBuf> {
+    let mut children: Vec<PathBuf> = match std::fs::read_dir(dir) {
+        Ok(rd) => rd.flatten().map(|e| e.path()).collect(),
+        Err(_) => Vec::new(),
+    };
+    children.sort();
+    children
+}
+
+/// Match a single path-segment glob against `text`: `*` matches any run
+/// (including empty), `?` matches exactly one character. `**` is handled across
+/// segments by [`glob_segments`], never here.
+fn wildcard_match(pattern: &str, text: &str) -> bool {
+    let p: Vec<char> = pattern.chars().collect();
+    let t: Vec<char> = text.chars().collect();
+    let (mut pi, mut ti) = (0usize, 0usize);
+    // Backtrack anchor: the last `*` seen and the text index it started at.
+    let (mut star, mut star_ti): (Option<usize>, usize) = (None, 0);
+    while ti < t.len() {
+        if pi < p.len() && (p[pi] == '?' || p[pi] == t[ti]) {
+            pi += 1;
+            ti += 1;
+        } else if pi < p.len() && p[pi] == '*' {
+            star = Some(pi);
+            star_ti = ti;
+            pi += 1;
+        } else if let Some(sp) = star {
+            // Mismatch after a `*`: extend the `*` by one text char.
+            pi = sp + 1;
+            star_ti += 1;
+            ti = star_ti;
+        } else {
+            return false;
+        }
+    }
+    while pi < p.len() && p[pi] == '*' {
+        pi += 1;
+    }
+    pi == p.len()
+}
+
 /// Convert a [`crate::api::release_report::ReleaseReport`] and the
 /// [`PlannedEntry`] it came from into a [`PublishEntry`] for the batch
 /// report.
@@ -1907,6 +2373,7 @@ mod tests {
             path: None,
             repository: repository.map(str::to_string),
             pin: false,
+            description: None,
         }
     }
 
@@ -3442,5 +3909,285 @@ mod tests {
             path_count, 1,
             "path must appear exactly once in error (no double-path), got: {msg}"
         );
+    }
+
+    // ── Description companion: parsing, probe, glob, resolution ───────────
+
+    #[test]
+    fn description_spec_parses_untagged_bool_and_table() {
+        // Per-entry `description = false` is the bool opt-out; a
+        // `[<kind>.<name>.description]` table is the override. Both parse from
+        // the same field via the untagged enum.
+        let toml = r#"
+            registry = "r.example"
+
+            [description]
+            readme = "README.md"
+            logo = "assets/logo.png"
+
+            [skills.optout]
+            version = "0.1.0"
+            description = false
+
+            [skills.override]
+            version = "0.1.0"
+            [skills.override.description]
+            readme = "skills/override/README.md"
+        "#;
+        let m: PublishManifest = toml::from_str(toml).unwrap();
+        assert!(m.description.is_some(), "top-level [description] parses");
+        assert_eq!(
+            m.description.as_ref().unwrap().readme.as_deref(),
+            Some(Path::new("README.md"))
+        );
+        assert!(matches!(
+            m.skills["optout"].description,
+            Some(EntryDescription::Enabled(false))
+        ));
+        assert!(matches!(
+            m.skills["override"].description,
+            Some(EntryDescription::Spec(_))
+        ));
+    }
+
+    #[test]
+    fn probe_precedence_readme_changelog_and_first_logo_hit_wins() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        write(&dir.join("README.md"), "# r\n");
+        write(&dir.join("CHANGELOG.md"), "# c\n");
+        // Two logo candidates present; the probe order picks assets/logo.png.
+        std::fs::create_dir_all(dir.join("assets")).unwrap();
+        std::fs::write(dir.join("assets/logo.png"), b"png").unwrap();
+        std::fs::write(dir.join("logo.svg"), b"svg").unwrap();
+
+        let files = probe_conventional_description(dir);
+        let names: Vec<&str> = files.iter().map(|(n, _)| n.as_str()).collect();
+        assert!(names.contains(&"README.md"));
+        assert!(names.contains(&"CHANGELOG.md"));
+        assert!(names.contains(&"logo.png"), "assets/logo.png wins the probe order");
+        assert!(!names.contains(&"logo.svg"), "only the first logo hit rides");
+
+        // Which absolute path backs logo.png? The assets/ one.
+        let logo = files.iter().find(|(n, _)| n == "logo.png").unwrap();
+        assert!(logo.1.ends_with("assets/logo.png"));
+    }
+
+    #[test]
+    fn probe_empty_when_no_conventional_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert!(probe_conventional_description(tmp.path()).is_empty());
+    }
+
+    #[test]
+    fn wildcard_match_star_and_question() {
+        assert!(wildcard_match("*.png", "diagram.png"));
+        assert!(wildcard_match("logo-*.svg", "logo-dark.svg"));
+        assert!(wildcard_match("img?.png", "img1.png"));
+        assert!(wildcard_match("*", "anything"));
+        assert!(wildcard_match("a*b*c", "axxbyyc"));
+        assert!(!wildcard_match("*.png", "diagram.svg"));
+        assert!(!wildcard_match("img?.png", "img12.png"));
+        assert!(!wildcard_match("exact", "different"));
+    }
+
+    #[test]
+    fn expand_glob_keeps_relative_paths() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        write(&dir.join("docs/img/a.png"), "a");
+        write(&dir.join("docs/img/b.png"), "b");
+        write(&dir.join("docs/img/skip.svg"), "s");
+        write(&dir.join("docs/nested/deep/c.png"), "c");
+
+        let mut hits = expand_description_glob(dir, "docs/img/*.png");
+        hits.sort();
+        let names: Vec<&str> = hits.iter().map(|(n, _)| n.as_str()).collect();
+        assert_eq!(
+            names,
+            vec!["docs/img/a.png", "docs/img/b.png"],
+            "glob keeps relative paths"
+        );
+
+        // `**` crosses segments.
+        let mut deep = expand_description_glob(dir, "docs/**/*.png");
+        deep.sort();
+        let deep_names: Vec<&str> = deep.iter().map(|(n, _)| n.as_str()).collect();
+        assert!(deep_names.contains(&"docs/img/a.png"));
+        assert!(deep_names.contains(&"docs/nested/deep/c.png"), "** matches any depth");
+    }
+
+    #[test]
+    fn resolve_spec_maps_wire_names_and_dedups_include() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        write(&dir.join("README.md"), "# r\n");
+        write(&dir.join("docs/CHANGES.md"), "# c\n");
+        std::fs::create_dir_all(dir.join("assets")).unwrap();
+        std::fs::write(dir.join("assets/brand.svg"), b"<svg/>").unwrap();
+        write(&dir.join("img/extra.png"), "x");
+
+        let spec = DescriptionSpec {
+            readme: Some(PathBuf::from("README.md")),
+            logo: Some(PathBuf::from("assets/brand.svg")),
+            changelog: Some(PathBuf::from("docs/CHANGES.md")),
+            include: vec!["img/*.png".to_string()],
+            publish: None,
+        };
+        let files = resolve_description_spec(&spec, dir, Path::new("publish.toml")).unwrap();
+        let names: Vec<&str> = files.iter().map(|(n, _)| n.as_str()).collect();
+        // Sorted by packed name; logo maps by extension to logo.svg.
+        assert_eq!(names, vec!["CHANGELOG.md", "README.md", "img/extra.png", "logo.svg"]);
+    }
+
+    #[test]
+    fn resolve_spec_missing_explicit_path_is_data_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let spec = DescriptionSpec {
+            readme: Some(PathBuf::from("does-not-exist.md")),
+            logo: None,
+            changelog: None,
+            include: vec![],
+            publish: None,
+        };
+        let err = resolve_description_spec(&spec, tmp.path(), Path::new("publish.toml")).unwrap_err();
+        assert_eq!(crate::error::classify_error(&err), ExitCode::DataError);
+        assert!(format!("{err:#}").contains("does-not-exist.md"));
+    }
+
+    #[test]
+    fn resolve_spec_empty_is_data_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let spec = DescriptionSpec {
+            readme: None,
+            logo: None,
+            changelog: None,
+            include: vec![],
+            publish: None,
+        };
+        let err = resolve_description_spec(&spec, tmp.path(), Path::new("publish.toml")).unwrap_err();
+        assert_eq!(crate::error::classify_error(&err), ExitCode::DataError);
+    }
+
+    /// Build a one-skill planned-entry set targeting `repo` for description tests.
+    fn one_entry(name: &str, repo: &str) -> Vec<PlannedEntry> {
+        vec![PlannedEntry {
+            kind: ArtifactKind::Skill,
+            name: name.to_string(),
+            path: PathBuf::from("skills").join(name),
+            reference: format!("{repo}:1.0.0"),
+            pin: false,
+            name_not_appended: false,
+        }]
+    }
+
+    #[test]
+    fn plan_descriptions_precedence_per_entry_over_top_level_over_probe() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        // Conventional probe file (lowest precedence).
+        write(&dir.join("README.md"), "# probe\n");
+        // Top-level spec file.
+        write(&dir.join("top.md"), "# top\n");
+        // Per-entry override file.
+        write(&dir.join("entry.md"), "# entry\n");
+
+        let manifest: PublishManifest = toml::from_str(
+            "registry = \"localhost:5000\"\n\
+             [description]\nreadme = \"top.md\"\n\
+             [skills.demo]\nversion = \"1.0.0\"\n[skills.demo.description]\nreadme = \"entry.md\"\n",
+        )
+        .unwrap();
+        let entries = one_entry("demo", "localhost:5000/acme/skills/demo");
+        let planned = plan_descriptions(&manifest, &entries, dir, Path::new("publish.toml")).unwrap();
+        assert_eq!(planned.len(), 1);
+        assert_eq!(planned[0].repository, "localhost:5000/acme/skills/demo");
+        // The per-entry override wins: entry.md packed as README.md.
+        assert!(
+            planned[0]
+                .files
+                .iter()
+                .any(|(n, p)| n == "README.md" && p.ends_with("entry.md"))
+        );
+    }
+
+    #[test]
+    fn plan_descriptions_false_opts_entry_out() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        write(&dir.join("README.md"), "# r\n");
+        let manifest: PublishManifest = toml::from_str(
+            "registry = \"localhost:5000\"\n[description]\nreadme = \"README.md\"\n\
+             [skills.demo]\nversion = \"1.0.0\"\ndescription = false\n",
+        )
+        .unwrap();
+        let entries = one_entry("demo", "localhost:5000/acme/skills/demo");
+        let planned = plan_descriptions(&manifest, &entries, dir, Path::new("publish.toml")).unwrap();
+        assert!(
+            planned.is_empty(),
+            "description = false opts the entry out of the fan-out"
+        );
+    }
+
+    #[test]
+    fn plan_descriptions_top_level_kill_switch_and_probe_fallback() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        write(&dir.join("README.md"), "# r\n");
+
+        // publish = false kills the auto-companion even with a probe hit.
+        let killed: PublishManifest = toml::from_str(
+            "registry = \"localhost:5000\"\n[description]\npublish = false\n\
+             [skills.demo]\nversion = \"1.0.0\"\n",
+        )
+        .unwrap();
+        let entries = one_entry("demo", "localhost:5000/acme/skills/demo");
+        assert!(
+            plan_descriptions(&killed, &entries, dir, Path::new("publish.toml"))
+                .unwrap()
+                .is_empty(),
+            "publish = false is the manifest-wide kill switch"
+        );
+
+        // No [description] table → conventional probe finds README.md.
+        let probed: PublishManifest =
+            toml::from_str("registry = \"localhost:5000\"\n[skills.demo]\nversion = \"1.0.0\"\n").unwrap();
+        let planned = plan_descriptions(&probed, &entries, dir, Path::new("publish.toml")).unwrap();
+        assert_eq!(planned.len(), 1, "conventional probe publishes a companion by default");
+    }
+
+    #[test]
+    fn plan_descriptions_fans_out_to_each_repo_deduped() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        write(&dir.join("README.md"), "# r\n");
+        let manifest: PublishManifest = toml::from_str(
+            "registry = \"localhost:5000\"\n[description]\nreadme = \"README.md\"\n\
+             [skills.a]\nversion = \"1.0.0\"\n[skills.b]\nversion = \"1.0.0\"\n",
+        )
+        .unwrap();
+        let entries = vec![
+            PlannedEntry {
+                kind: ArtifactKind::Skill,
+                name: "a".to_string(),
+                path: PathBuf::from("skills/a"),
+                reference: "localhost:5000/acme/skills/a:1.0.0".to_string(),
+                pin: false,
+                name_not_appended: false,
+            },
+            PlannedEntry {
+                kind: ArtifactKind::Skill,
+                name: "b".to_string(),
+                path: PathBuf::from("skills/b"),
+                reference: "localhost:5000/acme/skills/b:1.0.0".to_string(),
+                pin: false,
+                name_not_appended: false,
+            },
+        ];
+        let planned = plan_descriptions(&manifest, &entries, dir, Path::new("publish.toml")).unwrap();
+        assert_eq!(planned.len(), 2, "top-level companion fans out to every entry's repo");
+        let repos: Vec<&str> = planned.iter().map(|p| p.repository.as_str()).collect();
+        assert!(repos.contains(&"localhost:5000/acme/skills/a"));
+        assert!(repos.contains(&"localhost:5000/acme/skills/b"));
     }
 }

--- a/src/command/publish.rs
+++ b/src/command/publish.rs
@@ -828,8 +828,7 @@ async fn run_announce(
         let id = crate::oci::Identifier::parse(&planned.reference)
             .map_err(|e| anyhow::Error::from(crate::error::Error::from(e)))?;
         let reference = format!("{}/{}", id.registry(), id.repository());
-        let (description, repository_url) =
-            crate::catalog::index_announce::pointer_metadata(access.as_ref(), &id).await;
+        let meta = crate::catalog::index_announce::pointer_metadata(access.as_ref(), &id).await;
         packages.push(AnnouncePackage {
             name: planned.name.clone(),
             kind: kind_str(planned.kind).to_string(),
@@ -837,8 +836,12 @@ async fn run_announce(
             // The index spec requires a description; grim-published
             // artifacts always carry the annotation, but degrade honestly
             // for foreign/unreachable manifests.
-            description: description.unwrap_or_else(|| format!("grimoire {} {}", kind_str(planned.kind), planned.name)),
-            repository_url,
+            description: meta
+                .description
+                .unwrap_or_else(|| format!("grimoire {} {}", kind_str(planned.kind), planned.name)),
+            repository_url: meta.repository_url,
+            keywords: meta.keywords,
+            summary: meta.summary,
         });
     }
 

--- a/src/command/release.rs
+++ b/src/command/release.rs
@@ -419,7 +419,7 @@ fn parse_reference(
 /// [`crate::command::primary_registry_global_fallback`] is used instead of
 /// the legacy `[options].default_registry` chain so a `[[registries]]`-only
 /// global config is still honored.
-fn release_default_registry(ctx: &Context) -> String {
+pub(crate) fn release_default_registry(ctx: &Context) -> String {
     use super::scope_resolution;
     // Best-effort: discover the project scope. On miss (no config in tree),
     // fall back through the global-[[registries]]-aware helper so a user with

--- a/src/command/schema.rs
+++ b/src/command/schema.rs
@@ -209,6 +209,39 @@ mod tests {
     }
 
     #[test]
+    fn publish_schema_documents_description_companion_fields() {
+        // The description companion adds an optional top-level `[description]`
+        // table and an optional per-entry `description` — `registry` must stay
+        // the only required top-level field.
+        let v = parsed(SchemaKind::Publish);
+        assert!(
+            v["properties"]["description"].is_object(),
+            "top-level description must be a documented manifest property"
+        );
+        let required = v["required"].as_array().expect("required is an array");
+        assert_eq!(required.len(), 1, "only `registry` required, got: {required:?}");
+        assert_eq!(required[0], "registry");
+        // Per-entry `description` is a documented (optional) entry property.
+        let entry = v["$defs"]["PublishEntrySpec"]
+            .as_object()
+            .expect("PublishEntrySpec definition present");
+        assert!(
+            entry["properties"]["description"].is_object(),
+            "per-entry description must be a documented property"
+        );
+        // The DescriptionSpec definition documents the well-known members.
+        let spec = v["$defs"]["DescriptionSpec"]
+            .as_object()
+            .expect("DescriptionSpec definition present");
+        for key in ["readme", "logo", "changelog", "include", "publish"] {
+            assert!(
+                spec["properties"][key].is_object(),
+                "DescriptionSpec must document `{key}`"
+            );
+        }
+    }
+
+    #[test]
     fn publish_schema_documents_catalog_wide_version() {
         // Issue #29: the top-level `version` / `version_prefix` are documented
         // optional manifest properties; `registry` stays the only required one.

--- a/src/command/search.rs
+++ b/src/command/search.rs
@@ -149,6 +149,7 @@ pub async fn run(ctx: &Context, args: &SearchArgs) -> anyhow::Result<(SearchRepo
             latest_tag: r.latest_tag,
             version: r.version,
             deprecated: r.deprecated,
+            replaced_by: r.replaced_by,
             status: r.badge,
         })
         .collect();

--- a/src/config/project_config.rs
+++ b/src/config/project_config.rs
@@ -373,6 +373,10 @@ pub struct BundleMetadata {
     /// Deprecation notice → `com.grimoire.deprecated`. A non-empty message
     /// marks the bundle deprecated; emitted only when present.
     pub deprecated: Option<String>,
+    /// Replacement reference → `com.grimoire.replaced-by`. Names the
+    /// successor artifact; emitted only when present, independent of
+    /// [`Self::deprecated`].
+    pub replaced_by: Option<String>,
 }
 
 /// A parsed bundle source: validated members plus catalog metadata.
@@ -430,6 +434,8 @@ struct RawBundleSource {
     repository: Option<String>,
     #[serde(default)]
     deprecated: Option<String>,
+    #[serde(default, rename = "replaced-by")]
+    replaced_by: Option<String>,
 }
 
 /// Parse + validate a bundle source: members through [`parse_member_map`]
@@ -451,6 +457,7 @@ fn parse_bundle_source(s: &str, path: PathBuf) -> Result<BundleSource, ConfigErr
             description: raw.description,
             repository: raw.repository,
             deprecated: raw.deprecated,
+            replaced_by: raw.replaced_by,
         },
     })
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -283,6 +283,27 @@ fn classify_auth(err: &AuthError) -> ExitCode {
     }
 }
 
+/// Maps an error chain to a machine-readable failure `reason`, or `None`
+/// when no specific subtype applies.
+///
+/// A companion to [`classify_error`]: same free-function shape and same
+/// chain walk (first cause that downcasts to [`Error`] decides), but it
+/// yields the optional `reason` subtype the JSON error envelope carries
+/// alongside `code`/`exit`. The string is kebab-case and additive —
+/// consumers must tolerate both absence and unknown future values. Only
+/// the stale-lock refusal is annotated today; every other error is `None`.
+pub fn classify_reason(err: &anyhow::Error) -> Option<&'static str> {
+    for cause in err.chain() {
+        if let Some(e) = cause.downcast_ref::<Error>() {
+            return match e {
+                Error::Resolve(re) if matches!(re.kind, ResolveErrorKind::StaleLock { .. }) => Some("stale-lock"),
+                _ => None,
+            };
+        }
+    }
+    None
+}
+
 /// `PermissionDenied` → `NoPermission` (77); any other I/O → `IoError` (74).
 fn classify_io(io: &std::io::Error) -> ExitCode {
     if io.kind() == std::io::ErrorKind::PermissionDenied {
@@ -534,6 +555,62 @@ mod tests {
             let err: anyhow::Error = Error::from(ReleaseError::without_reference(kind)).into();
             assert_eq!(classify_error(&err), ExitCode::DataError);
         }
+    }
+
+    #[test]
+    fn stale_lock_classifies_reason_as_stale_lock() {
+        use crate::oci::ArtifactKind;
+        use crate::oci::reference::ArtifactRef;
+        let reference = ArtifactRef::registry(
+            ArtifactKind::Skill,
+            "code-review",
+            Identifier::parse("ghcr.io/acme/code-review:stable").unwrap(),
+        );
+        let err: anyhow::Error = Error::from(ResolveError::new(
+            reference,
+            ResolveErrorKind::StaleLock {
+                previous_hash: "sha256:aaa".to_string(),
+                current_hash: "sha256:bbb".to_string(),
+            },
+        ))
+        .into();
+        assert_eq!(classify_error(&err), ExitCode::DataError);
+        assert_eq!(classify_reason(&err), Some("stale-lock"));
+    }
+
+    #[test]
+    fn other_errors_carry_no_reason() {
+        // A representative data error and a not-found error both classify to
+        // an exit code but to no reason subtype — the field must stay absent.
+        let data: anyhow::Error = Error::from(DigestError::Invalid("nope".to_string())).into();
+        assert_eq!(classify_reason(&data), None);
+
+        let usage: anyhow::Error = Error::from(CommandError::LoginInput("bad input")).into();
+        assert_eq!(classify_reason(&usage), None);
+
+        // A non-Grimoire error (the classify_error fall-through case) also
+        // has no reason.
+        assert_eq!(classify_reason(&anyhow::anyhow!("unrelated")), None);
+    }
+
+    #[test]
+    fn reason_survives_anyhow_context_layers() {
+        use crate::oci::ArtifactKind;
+        use crate::oci::reference::ArtifactRef;
+        let reference = ArtifactRef::registry(
+            ArtifactKind::Skill,
+            "code-review",
+            Identifier::parse("ghcr.io/acme/code-review:stable").unwrap(),
+        );
+        let err = anyhow::Error::from(Error::from(ResolveError::new(
+            reference,
+            ResolveErrorKind::StaleLock {
+                previous_hash: "sha256:aaa".to_string(),
+                current_hash: "sha256:bbb".to_string(),
+            },
+        )))
+        .context("while re-resolving the lock");
+        assert_eq!(classify_reason(&err), Some("stale-lock"));
     }
 
     #[test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,10 +3,12 @@
 
 //! Top-level error type and the error → exit-code classifier.
 //!
-//! [`classify_error`] is a free function (not a trait method) so the
-//! dependency direction stays clean: errors do not depend on the exit-code
-//! taxonomy. It walks the `anyhow` chain, downcasts to [`Error`], and maps
-//! each known kind to a typed [`ExitCode`].
+//! [`classify`] is a free function (not a trait method) so the dependency
+//! direction stays clean: errors do not depend on the exit-code taxonomy.
+//! It walks the `anyhow` chain once, downcasts to [`Error`], and maps each
+//! known kind to a [`Classification`] (exit code plus an optional
+//! machine-readable [`ErrorReason`]). [`classify_error`] is a thin wrapper
+//! kept for callers that only need the exit code.
 
 use crate::auth::auth_error::AuthError;
 use crate::catalog::catalog_error::{CatalogError, CatalogErrorKind};
@@ -78,32 +80,71 @@ pub enum Error {
     Announce(#[from] AnnounceError),
 }
 
-/// Maps an error chain to a process exit code.
+/// Machine-readable failure `reason` subtype for the JSON error envelope
+/// (`docs/src/json-interface.md`).
 ///
-/// Walks `err.chain()`, downcasts each cause to [`Error`], and
+/// Kebab-case via [`std::fmt::Display`] — the wire path (`main.rs`
+/// `error_document`) builds the JSON `reason` string through that
+/// rendering, not a `Serialize` derive. Additive and forward-compatible:
+/// consumers must tolerate both absence and unknown future values. Only
+/// the stale-lock refusal is annotated today.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ErrorReason {
+    /// A resolve was refused because the lock's recorded hash no longer
+    /// matches what the registry currently serves.
+    StaleLock,
+}
+
+impl std::fmt::Display for ErrorReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::StaleLock => "stale-lock",
+        })
+    }
+}
+
+/// The result of classifying an error chain: the process exit code plus
+/// an optional machine-readable [`ErrorReason`] subtype.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Classification {
+    pub exit: ExitCode,
+    pub reason: Option<ErrorReason>,
+}
+
+impl Classification {
+    /// A classification carrying no reason subtype — the common case.
+    fn new(exit: ExitCode) -> Self {
+        Self { exit, reason: None }
+    }
+}
+
+/// Maps an error chain to a [`Classification`] (exit code + optional
+/// reason subtype).
+///
+/// Walks `err.chain()` once, downcasts each cause to [`Error`], and
 /// exhaustively maps every Phase 1 variant. Anything not classified falls
-/// through to [`ExitCode::Failure`]; the fall-through is locked by a test
-/// so it cannot silently change.
-pub fn classify_error(err: &anyhow::Error) -> ExitCode {
+/// through to [`ExitCode::Failure`] with no reason; the fall-through is
+/// locked by a test so it cannot silently change.
+pub fn classify(err: &anyhow::Error) -> Classification {
     for cause in err.chain() {
         if let Some(e) = cause.downcast_ref::<Error>() {
             // Exhaustive match: a new variant fails to compile until it is
             // explicitly classified here.
             return match e {
-                Error::Identifier(_) => ExitCode::DataError,
-                Error::Digest(_) => ExitCode::DataError,
-                Error::PinnedIdentifier(_) => ExitCode::DataError,
-                Error::Config(ce) => classify_config(ce),
-                Error::Lock(le) => classify_lock(le),
-                Error::Access(ae) => classify_access(ae),
+                Error::Identifier(_) => Classification::new(ExitCode::DataError),
+                Error::Digest(_) => Classification::new(ExitCode::DataError),
+                Error::PinnedIdentifier(_) => Classification::new(ExitCode::DataError),
+                Error::Config(ce) => Classification::new(classify_config(ce)),
+                Error::Lock(le) => Classification::new(classify_lock(le)),
+                Error::Access(ae) => Classification::new(classify_access(ae)),
                 Error::Resolve(re) => classify_resolve(re),
-                Error::Install(ie) => classify_install(ie),
-                Error::Anchor(ae) => classify_anchor(ae),
-                Error::Skill(se) => classify_skill(se),
-                Error::Release(re) => classify_release(re),
-                Error::Catalog(ce) => classify_catalog(ce),
-                Error::Auth(ae) => classify_auth(ae),
-                Error::Command(ce) => match ce {
+                Error::Install(ie) => Classification::new(classify_install(ie)),
+                Error::Anchor(ae) => Classification::new(classify_anchor(ae)),
+                Error::Skill(se) => Classification::new(classify_skill(se)),
+                Error::Release(re) => Classification::new(classify_release(re)),
+                Error::Catalog(ce) => Classification::new(classify_catalog(ce)),
+                Error::Auth(ae) => Classification::new(classify_auth(ae)),
+                Error::Command(ce) => Classification::new(match ce {
                     CommandError::LockMissing { .. } => ExitCode::NotFound,
                     CommandError::LockStale { .. } => ExitCode::DataError,
                     CommandError::NoLoginRegistry => ExitCode::ConfigError,
@@ -113,17 +154,26 @@ pub fn classify_error(err: &anyhow::Error) -> ExitCode {
                     CommandError::InvalidBindingName { .. } => ExitCode::UsageError,
                     CommandError::ConfigUsage(_) => ExitCode::UsageError,
                     CommandError::ConfigValue(_) => ExitCode::DataError,
-                },
+                }),
                 // Announce needs remote resources (the index repository, the
                 // GitHub API); a local I/O fault classifies as I/O.
-                Error::Announce(ae) => match ae {
+                Error::Announce(ae) => Classification::new(match ae {
                     AnnounceError::Io(io) => classify_io(io),
                     AnnounceError::Git { .. } | AnnounceError::OwnerLookup { .. } => ExitCode::Unavailable,
-                },
+                }),
             };
         }
     }
-    ExitCode::Failure
+    Classification::new(ExitCode::Failure)
+}
+
+/// Maps an error chain to a process exit code.
+///
+/// Thin wrapper over [`classify`] for callers that only need the exit
+/// code, kept so the many exit-code-only call sites across the codebase
+/// need no changes.
+pub fn classify_error(err: &anyhow::Error) -> ExitCode {
+    classify(err).exit
 }
 
 /// Map a config-tier error to an exit code.
@@ -173,18 +223,26 @@ fn classify_access(err: &AccessError) -> ExitCode {
     }
 }
 
-/// Map a resolution-tier error to an exit code.
-fn classify_resolve(err: &ResolveError) -> ExitCode {
+/// Map a resolution-tier error to a classification. The only arm carrying
+/// a reason subtype is `StaleLock` — assigned right here, in the same
+/// match arm that decides its exit code, so the two can never drift apart.
+fn classify_resolve(err: &ResolveError) -> Classification {
     match &err.kind {
-        ResolveErrorKind::TagNotFound | ResolveErrorKind::BundleNotFound => ExitCode::NotFound,
-        ResolveErrorKind::AuthFailure(_) => ExitCode::AuthError,
-        ResolveErrorKind::RegistryUnreachable(_) | ResolveErrorKind::ResolveTimeout => ExitCode::Unavailable,
-        ResolveErrorKind::StaleLock { .. } | ResolveErrorKind::BundleInvalid(_) | ResolveErrorKind::LocalSource(_) => {
-            ExitCode::DataError
+        ResolveErrorKind::TagNotFound | ResolveErrorKind::BundleNotFound => Classification::new(ExitCode::NotFound),
+        ResolveErrorKind::AuthFailure(_) => Classification::new(ExitCode::AuthError),
+        ResolveErrorKind::RegistryUnreachable(_) | ResolveErrorKind::ResolveTimeout => {
+            Classification::new(ExitCode::Unavailable)
+        }
+        ResolveErrorKind::StaleLock { .. } => Classification {
+            exit: ExitCode::DataError,
+            reason: Some(ErrorReason::StaleLock),
+        },
+        ResolveErrorKind::BundleInvalid(_) | ResolveErrorKind::LocalSource(_) => {
+            Classification::new(ExitCode::DataError)
         }
         // A bundle conflict is a misconfiguration of the user's own
         // declaration (two bundles disagree), not malformed external data.
-        ResolveErrorKind::BundleConflict { .. } => ExitCode::ConfigError,
+        ResolveErrorKind::BundleConflict { .. } => Classification::new(ExitCode::ConfigError),
     }
 }
 
@@ -281,27 +339,6 @@ fn classify_auth(err: &AuthError) -> ExitCode {
             _ => ExitCode::AuthError,
         },
     }
-}
-
-/// Maps an error chain to a machine-readable failure `reason`, or `None`
-/// when no specific subtype applies.
-///
-/// A companion to [`classify_error`]: same free-function shape and same
-/// chain walk (first cause that downcasts to [`Error`] decides), but it
-/// yields the optional `reason` subtype the JSON error envelope carries
-/// alongside `code`/`exit`. The string is kebab-case and additive —
-/// consumers must tolerate both absence and unknown future values. Only
-/// the stale-lock refusal is annotated today; every other error is `None`.
-pub fn classify_reason(err: &anyhow::Error) -> Option<&'static str> {
-    for cause in err.chain() {
-        if let Some(e) = cause.downcast_ref::<Error>() {
-            return match e {
-                Error::Resolve(re) if matches!(re.kind, ResolveErrorKind::StaleLock { .. }) => Some("stale-lock"),
-                _ => None,
-            };
-        }
-    }
-    None
 }
 
 /// `PermissionDenied` → `NoPermission` (77); any other I/O → `IoError` (74).
@@ -575,7 +612,13 @@ mod tests {
         ))
         .into();
         assert_eq!(classify_error(&err), ExitCode::DataError);
-        assert_eq!(classify_reason(&err), Some("stale-lock"));
+        assert_eq!(
+            classify(&err),
+            Classification {
+                exit: ExitCode::DataError,
+                reason: Some(ErrorReason::StaleLock),
+            }
+        );
     }
 
     #[test]
@@ -583,14 +626,14 @@ mod tests {
         // A representative data error and a not-found error both classify to
         // an exit code but to no reason subtype — the field must stay absent.
         let data: anyhow::Error = Error::from(DigestError::Invalid("nope".to_string())).into();
-        assert_eq!(classify_reason(&data), None);
+        assert_eq!(classify(&data).reason, None);
 
         let usage: anyhow::Error = Error::from(CommandError::LoginInput("bad input")).into();
-        assert_eq!(classify_reason(&usage), None);
+        assert_eq!(classify(&usage).reason, None);
 
         // A non-Grimoire error (the classify_error fall-through case) also
         // has no reason.
-        assert_eq!(classify_reason(&anyhow::anyhow!("unrelated")), None);
+        assert_eq!(classify(&anyhow::anyhow!("unrelated")).reason, None);
     }
 
     #[test]
@@ -610,7 +653,7 @@ mod tests {
             },
         )))
         .context("while re-resolving the lock");
-        assert_eq!(classify_reason(&err), Some("stale-lock"));
+        assert_eq!(classify(&err).reason, Some(ErrorReason::StaleLock));
     }
 
     #[test]

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -519,16 +519,7 @@ pub async fn describe_artifact(
 
     let a = &manifest.annotations;
     let get = |k: &str| a.get(k).cloned();
-    let keywords = a
-        .get("com.grimoire.keywords")
-        .map(|k| {
-            k.split(',')
-                .map(str::trim)
-                .filter(|s| !s.is_empty())
-                .map(str::to_string)
-                .collect::<Vec<_>>()
-        })
-        .unwrap_or_default();
+    let keywords = crate::oci::annotations::keywords_from_annotations(a);
 
     Ok(DescribeReport {
         reference: id.to_string(),

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -29,7 +29,7 @@
 //! still useful in-context).
 
 use std::collections::BTreeMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use anyhow::anyhow;
@@ -40,12 +40,13 @@ use serde::Serialize;
 use crate::config::ResolvedRegistry;
 use crate::config::scope::ConfigScope;
 use crate::install::client_target::ClientTarget;
-use crate::install::materializer::{TarEntryData, unpack_tar_in_memory};
+use crate::install::materializer::{ArtifactMaterializer, DefaultMaterializer, TarEntryData, unpack_tar_in_memory};
 use crate::oci::access::error::{AccessError, AccessErrorKind};
 use crate::oci::access::{OciAccess, Operation};
 use crate::oci::bundle::BUNDLE_LAYER_SIZE_LIMIT;
 use crate::oci::mcp::{MCP_LAYER_SIZE_LIMIT, McpDescriptor};
-use crate::oci::{ArtifactKind, Identifier, PinnedIdentifier};
+use crate::oci::{ArtifactKind, ArtifactRef, Identifier, PinnedIdentifier};
+use crate::resolve::{ResolveError, ResolveErrorKind};
 
 /// Upper bound on a fetched layer blob. Checked against the manifest's
 /// layer-descriptor `size` before download (a cheap reject for an
@@ -76,6 +77,22 @@ where
     result.map_err(|e| anyhow::Error::from(crate::error::Error::from(e)))
 }
 
+/// Build a not-found error for a resolved `id` the registry has no tag or
+/// manifest for. Classifies to `NotFound` (79) — the documented fetch
+/// taxonomy (`docs/src/commands.md`: "a missing repository is a not-found
+/// failure (parity with grim fetch)") — by routing through the existing
+/// [`ResolveErrorKind::TagNotFound`] classification rather than a bare
+/// `anyhow!` (which would fall through to the generic failure, 1).
+fn not_found(id: &Identifier) -> anyhow::Error {
+    // ponytail: the kind is unknown before the manifest read (this fires on
+    // the resolve miss), so a neutral `Skill` placeholder stands in — the
+    // reference name and source carry the signal.
+    anyhow::Error::from(crate::error::Error::from(ResolveError::new(
+        ArtifactRef::registry(ArtifactKind::Skill, id.name(), id.clone()),
+        ResolveErrorKind::TagNotFound,
+    )))
+}
+
 /// Resolved scope inputs for a fetch, computed once by the caller.
 ///
 /// Mirrors `catalog::BadgeContext` — the caller does scope/registry
@@ -93,6 +110,23 @@ pub struct FetchScope {
     pub warnings: Vec<String>,
 }
 
+/// What a fetched manifest turned out to be: a typed artifact kind, or a
+/// `__grimoire` description companion (`com.grimoire.kind: desc`) — a tar
+/// layer indexed by `README.md`, not an installable artifact. Replaces a
+/// former `kind: ArtifactKind` + `is_description: bool` pair on
+/// [`FetchedArtifact`], where the kind field held a lying placeholder
+/// (`ArtifactKind::Skill`) for the description case.
+///
+/// Closed internal enum: the binary is the only consumer, so matches stay
+/// total — no `#[non_exhaustive]`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FetchedPayload {
+    /// A typed, installable artifact.
+    Artifact(ArtifactKind),
+    /// A `__grimoire` description companion.
+    Description,
+}
+
 /// A resolved + fetched + digest-verified artifact layer (shared between
 /// `grim_fetch` and `grim_render`).
 #[derive(Debug)]
@@ -101,8 +135,8 @@ pub struct FetchedArtifact {
     pub identifier: Identifier,
     /// The pinned (digest-addressed) form of [`Self::identifier`].
     pub pinned: PinnedIdentifier,
-    /// The artifact kind, inferred from the manifest.
-    pub kind: ArtifactKind,
+    /// What the fetched manifest turned out to be.
+    pub payload: FetchedPayload,
     /// The artifact name (the reference's last path segment).
     pub name: String,
     /// The verified single-layer blob.
@@ -166,6 +200,92 @@ pub struct FetchReport {
     pub warnings: Vec<String>,
 }
 
+/// One member of a description companion bundle.
+#[derive(Debug, Serialize)]
+pub struct DescriptionFile {
+    /// Path inside the companion tree.
+    pub path: String,
+    /// Full size in bytes, as reported by the tar header.
+    pub size: u64,
+    /// The member content: UTF-8 text verbatim, or the base64 of a non-UTF-8
+    /// member when [`Self::encoding`] is `"base64"`.
+    pub content: String,
+    /// `"base64"` when [`Self::content`] is the base64 of a non-UTF-8 member;
+    /// omitted (UTF-8 text) otherwise.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub encoding: Option<String>,
+}
+
+/// The `grim fetch --description` result: the whole repository description
+/// companion with every member inline.
+///
+/// JSON format: `{ref, digest, kind: "desc", files: [{path, size, content,
+/// encoding?}], warnings?}`. Every member is inline (bounded by the 8 MiB
+/// layer gate, no per-file truncation) so the consumer reads the entire
+/// companion in one call.
+#[derive(Debug, Serialize)]
+pub struct DescriptionReport {
+    /// The fully-qualified resolved companion reference (`…:__grimoire`).
+    #[serde(rename = "ref")]
+    pub reference: String,
+    /// The resolved companion manifest digest.
+    pub digest: String,
+    /// Always `"desc"` — the companion discriminator.
+    pub kind: String,
+    /// Every member of the companion tree, sorted by path.
+    pub files: Vec<DescriptionFile>,
+    /// Non-fatal notes (degraded scope, …).
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub warnings: Vec<String>,
+}
+
+/// The `grim fetch --digest-only` result: a cheap resolve probe with no
+/// content download.
+///
+/// JSON format: `{ref, digest, warnings?}`. The digest equals the full
+/// fetch's manifest digest, so a consumer caches on it and skips unchanged
+/// downloads.
+#[derive(Debug, Serialize)]
+pub struct DigestReport {
+    /// The fully-qualified resolved reference.
+    #[serde(rename = "ref")]
+    pub reference: String,
+    /// The resolved manifest digest.
+    pub digest: String,
+    /// Non-fatal notes (degraded scope, …).
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub warnings: Vec<String>,
+}
+
+/// The tri-shaped `grim fetch` result: full content, a description bundle, or
+/// a bare digest probe. Serializes untagged, so each variant is its own flat
+/// JSON object (the MCP server and the CLI report render it directly).
+///
+/// Closed internal enum — the binary is the only consumer, so matches stay
+/// total (no `#[non_exhaustive]`).
+#[derive(Debug, Serialize)]
+#[serde(untagged)]
+pub enum FetchOutcome {
+    /// A resolved + shaped artifact document (default / `--vendor` / `--path`).
+    Content(Box<FetchReport>),
+    /// The repository description companion (`--description`).
+    Description(DescriptionReport),
+    /// A resolve-only digest probe (`--digest-only`).
+    Digest(DigestReport),
+}
+
+impl FetchOutcome {
+    /// Non-fatal warnings accumulated during resolution, for stderr surfacing
+    /// (the CLI keeps stdout a pure payload).
+    pub fn warnings(&self) -> &[String] {
+        match self {
+            Self::Content(r) => &r.warnings,
+            Self::Description(r) => &r.warnings,
+            Self::Digest(r) => &r.warnings,
+        }
+    }
+}
+
 /// Resolve `reference` against the pre-resolved scope's registries and
 /// fetch its single verified layer. `max_layer_size` gates the layer
 /// descriptor size before download (`None` ⇒ no generic gate — `grim_render`
@@ -201,15 +321,25 @@ pub async fn fetch_artifact(
     let name = id.name().to_string();
 
     // Pure read: `Query` never write-throughs the tag cache.
-    let digest = wrap(access.resolve_digest(&id, Operation::Query).await)?
-        .ok_or_else(|| anyhow!("reference '{id}' not found on the registry"))?;
+    let digest = wrap(access.resolve_digest(&id, Operation::Query).await)?.ok_or_else(|| not_found(&id))?;
     let pinned = PinnedIdentifier::try_from(id.clone_with_digest(digest))
         .map_err(|e| anyhow!("resolved digest did not pin '{id}': {e}"))?;
 
     let manifest = wrap(access.fetch_manifest(&pinned).await)?
         .ok_or_else(|| anyhow!("manifest for '{pinned}' not found on the registry"))?;
-    let kind = crate::oci::annotations::kind_from_manifest(&manifest)
-        .ok_or_else(|| anyhow!("'{pinned}' is not a Grimoire artifact (no kind on the manifest)"))?;
+    // A `__grimoire` description companion carries no artifact kind; it is a
+    // tar layer like a skill, so it takes the generic size cap below via the
+    // `_ => max_layer_size` arm rather than a real kind.
+    let is_description = crate::oci::description::is_description_manifest(&manifest);
+    let payload = match crate::oci::annotations::kind_from_manifest(&manifest) {
+        Some(kind) => FetchedPayload::Artifact(kind),
+        None if is_description => FetchedPayload::Description,
+        None => {
+            return Err(anyhow!(
+                "'{pinned}' is not a Grimoire artifact (no kind on the manifest)"
+            ));
+        }
+    };
     let layer = manifest.single_layer().ok_or_else(|| {
         anyhow!(
             "expected a single-layer artifact, manifest has {} layers",
@@ -219,9 +349,9 @@ pub async fn fetch_artifact(
 
     // Size gate on the (untrusted) descriptor BEFORE the transfer. The
     // publish-side kind caps always hold; the generic cap is the caller's.
-    let cap = match kind {
-        ArtifactKind::Mcp => Some(MCP_LAYER_SIZE_LIMIT),
-        ArtifactKind::Bundle => Some(BUNDLE_LAYER_SIZE_LIMIT),
+    let cap = match payload {
+        FetchedPayload::Artifact(ArtifactKind::Mcp) => Some(MCP_LAYER_SIZE_LIMIT),
+        FetchedPayload::Artifact(ArtifactKind::Bundle) => Some(BUNDLE_LAYER_SIZE_LIMIT),
         _ => max_layer_size,
     };
     let repo: Identifier = pinned.as_identifier().without_tag();
@@ -254,7 +384,7 @@ pub async fn fetch_artifact(
     Ok(FetchedArtifact {
         identifier: id,
         pinned,
-        kind,
+        payload,
         name,
         blob,
         scope: scope.scope,
@@ -294,7 +424,10 @@ pub async fn fetch_with_limit(
     let mut report = FetchReport {
         reference: fetched.identifier.to_string(),
         digest: fetched.pinned.strip_advisory().digest().to_string(),
-        kind: fetched.kind.to_string(),
+        kind: match fetched.payload {
+            FetchedPayload::Description => crate::oci::description::DESC_KIND.to_string(),
+            FetchedPayload::Artifact(kind) => kind.to_string(),
+        },
         name: fetched.name.clone(),
         vendor: vendor_client.map_or_else(|| "canonical".to_string(), |v| v.as_str().to_string()),
         path: path.map(str::to_string),
@@ -306,8 +439,15 @@ pub async fn fetch_with_limit(
         warnings: Vec::new(),
     };
 
-    match fetched.kind {
-        ArtifactKind::Skill | ArtifactKind::Rule | ArtifactKind::Agent => {
+    // A description companion is a tar layer like a skill, but indexed by
+    // `README.md` and never vendor-projected — handle it before the kind match.
+    match fetched.payload {
+        FetchedPayload::Description => {
+            if vendor_client.is_some() {
+                return Err(anyhow!(
+                    "a description companion has no vendor projection; omit --vendor"
+                ));
+            }
             let entries = wrap(unpack_tar_in_memory(&fetched.blob, doc_limit as u64))?;
             report.files = entries
                 .iter()
@@ -316,19 +456,11 @@ pub async fn fetch_with_limit(
                     size: e.size,
                 })
                 .collect();
-
-            let index_rel = match fetched.kind {
-                ArtifactKind::Skill => PathBuf::from(&fetched.name).join("SKILL.md"),
-                _ => PathBuf::from(format!("{}.md", fetched.name)),
-            };
-
             if let Some(path) = path {
-                // One support file: UTF-8 text verbatim, or base64 for a
-                // non-UTF-8 (binary) file within the size limit.
                 let entry = entries
                     .iter()
                     .find(|e| e.path == std::path::Path::new(path))
-                    .ok_or_else(|| anyhow!("no file '{path}' in this artifact (see the files listing)"))?;
+                    .ok_or_else(|| anyhow!("no file '{path}' in this description (see the files listing)"))?;
                 let (content, truncated, encoding) = path_content(entry)?;
                 report.content = content;
                 report.truncated = truncated;
@@ -336,65 +468,103 @@ pub async fn fetch_with_limit(
             } else {
                 let index = entries
                     .iter()
-                    .find(|e| e.path == index_rel)
-                    .ok_or_else(|| anyhow!("artifact is missing its '{}' index", index_rel.display()))?;
+                    .find(|e| e.path == std::path::Path::new("README.md"))
+                    .ok_or_else(|| anyhow!("description is missing its 'README.md' index"))?;
                 let (doc, doc_truncated) = entry_content(index)?;
+                report.content = doc;
                 report.truncated = doc_truncated;
-                report.content = match vendor_client {
-                    None => doc,
-                    Some(client) => {
-                        let projected = project_index(fetched.kind, &doc, client, &fetched.pinned, &mut warnings)?;
-                        match projected {
-                            // `None` ⇒ the canonical bytes ARE the projection.
-                            None => doc,
-                            Some(rendered) => rendered,
-                        }
-                    }
+            }
+        }
+        FetchedPayload::Artifact(kind) => match kind {
+            ArtifactKind::Skill | ArtifactKind::Rule | ArtifactKind::Agent => {
+                let entries = wrap(unpack_tar_in_memory(&fetched.blob, doc_limit as u64))?;
+                report.files = entries
+                    .iter()
+                    .map(|e| FetchFileEntry {
+                        path: e.path.to_string_lossy().into_owned(),
+                        size: e.size,
+                    })
+                    .collect();
+
+                let index_rel = match kind {
+                    ArtifactKind::Skill => PathBuf::from(&fetched.name).join("SKILL.md"),
+                    _ => PathBuf::from(format!("{}.md", fetched.name)),
                 };
-            }
-        }
-        ArtifactKind::Mcp => {
-            if path.is_some() {
-                return Err(anyhow!("mcp descriptors carry no support files; omit 'path'"));
-            }
-            let descriptor = McpDescriptor::from_layer_bytes(&fetched.blob)
-                .map_err(|e| anyhow!("invalid mcp descriptor layer: {e}"))?;
-            match vendor_client {
-                None => {
-                    let bytes = descriptor
-                        .to_layer_bytes()
-                        .map_err(|e| anyhow!("descriptor re-serialize failed: {e}"))?;
-                    report.content = String::from_utf8_lossy(&bytes).into_owned();
+
+                if let Some(path) = path {
+                    // One support file: UTF-8 text verbatim, or base64 for a
+                    // non-UTF-8 (binary) file within the size limit.
+                    let entry = entries
+                        .iter()
+                        .find(|e| e.path == std::path::Path::new(path))
+                        .ok_or_else(|| anyhow!("no file '{path}' in this artifact (see the files listing)"))?;
+                    let (content, truncated, encoding) = path_content(entry)?;
+                    report.content = content;
+                    report.truncated = truncated;
+                    report.encoding = encoding;
+                } else {
+                    let index = entries
+                        .iter()
+                        .find(|e| e.path == index_rel)
+                        .ok_or_else(|| anyhow!("artifact is missing its '{}' index", index_rel.display()))?;
+                    let (doc, doc_truncated) = entry_content(index)?;
+                    report.truncated = doc_truncated;
+                    report.content = match vendor_client {
+                        None => doc,
+                        Some(client) => {
+                            let projected = project_index(kind, &doc, client, &fetched.pinned, &mut warnings)?;
+                            match projected {
+                                // `None` ⇒ the canonical bytes ARE the projection.
+                                None => doc,
+                                Some(rendered) => rendered,
+                            }
+                        }
+                    };
                 }
-                Some(client) => {
-                    let (pointer, value) = client
-                        .vendor()
-                        .mcp_entry(fetched.scope, &fetched.name, &descriptor)
-                        .ok_or_else(|| {
-                            anyhow!(
-                                "client '{}' cannot represent this descriptor at {} scope",
-                                client.as_str(),
-                                fetched.scope
-                            )
-                        })?;
-                    report.pointer = Some(pointer);
-                    report.content = serde_json::to_string_pretty(&value)
-                        .map_err(|e| anyhow!("vendor entry serialize failed: {e}"))?;
+            }
+            ArtifactKind::Mcp => {
+                if path.is_some() {
+                    return Err(anyhow!("mcp descriptors carry no support files; omit 'path'"));
+                }
+                let descriptor = McpDescriptor::from_layer_bytes(&fetched.blob)
+                    .map_err(|e| anyhow!("invalid mcp descriptor layer: {e}"))?;
+                match vendor_client {
+                    None => {
+                        let bytes = descriptor
+                            .to_layer_bytes()
+                            .map_err(|e| anyhow!("descriptor re-serialize failed: {e}"))?;
+                        report.content = String::from_utf8_lossy(&bytes).into_owned();
+                    }
+                    Some(client) => {
+                        let (pointer, value) = client
+                            .vendor()
+                            .mcp_entry(fetched.scope, &fetched.name, &descriptor)
+                            .ok_or_else(|| {
+                                anyhow!(
+                                    "client '{}' cannot represent this descriptor at {} scope",
+                                    client.as_str(),
+                                    fetched.scope
+                                )
+                            })?;
+                        report.pointer = Some(pointer);
+                        report.content = serde_json::to_string_pretty(&value)
+                            .map_err(|e| anyhow!("vendor entry serialize failed: {e}"))?;
+                    }
                 }
             }
-        }
-        ArtifactKind::Bundle => {
-            if vendor_client.is_some() {
-                return Err(anyhow!(
-                    "bundles have no vendor projection (they expand into members); fetch a member instead"
-                ));
+            ArtifactKind::Bundle => {
+                if vendor_client.is_some() {
+                    return Err(anyhow!(
+                        "bundles have no vendor projection (they expand into members); fetch a member instead"
+                    ));
+                }
+                if path.is_some() {
+                    return Err(anyhow!("bundles carry no support files; omit 'path'"));
+                }
+                // The layer IS the member-list document.
+                report.content = String::from_utf8_lossy(&fetched.blob).into_owned();
             }
-            if path.is_some() {
-                return Err(anyhow!("bundles carry no support files; omit 'path'"));
-            }
-            // The layer IS the member-list document.
-            report.content = String::from_utf8_lossy(&fetched.blob).into_owned();
-        }
+        },
     }
 
     // Cap whatever content shape was produced (vendor projections and
@@ -413,6 +583,183 @@ pub async fn fetch_with_limit(
     }
     report.warnings = warnings;
     Ok(report)
+}
+
+/// Resolve `reference` and retarget its repository to the reserved
+/// `__grimoire` companion tag (dropping any caller-supplied tag/digest). The
+/// tag is a grim internal — it is composed here, never typed by the consumer.
+fn companion_reference(scope: &FetchScope, reference: &str) -> anyhow::Result<Identifier> {
+    let id = wrap(crate::config::resolve_reference(
+        reference,
+        &scope.registries,
+        &scope.short_id_default,
+    ))?;
+    Ok(id.clone_with_tag(crate::oci::description::DESC_TAG))
+}
+
+/// Fetch the repository description companion at `reference`'s reserved
+/// `__grimoire` tag, shaping every member inline. When `out` is `Some`, the
+/// companion tree is also unpacked into that directory through install's
+/// tar-materialize guard ([`DefaultMaterializer`]).
+///
+/// The repository is retargeted to the internal companion tag before
+/// resolution; the result must be a `com.grimoire.kind: desc` companion.
+/// Bounded by the 8 MiB layer gate — no per-file truncation, so the whole
+/// companion returns in one call.
+///
+/// # Errors
+///
+/// A missing companion (not-found, 79 — parity with `grim fetch`), an
+/// offline-uncached miss (81), a `__grimoire` manifest that is not a
+/// companion or an empty companion (data error, 65), or a filesystem failure
+/// writing `out`.
+pub async fn fetch_description(
+    scope: &FetchScope,
+    access: &Arc<dyn OciAccess>,
+    reference: &str,
+    out: Option<&Path>,
+) -> anyhow::Result<DescriptionReport> {
+    let companion = companion_reference(scope, reference)?;
+    let mut fetched = fetch_artifact(scope, access, &companion.to_string(), Some(FETCH_BLOB_SIZE_LIMIT)).await?;
+    if fetched.payload != FetchedPayload::Description {
+        // The `__grimoire` tag resolved to a non-companion manifest — bad
+        // external data (65), the same tier as an empty companion below.
+        return Err(anyhow::Error::from(crate::error::Error::from(
+            AccessError::with_identifier(
+                fetched.pinned.as_identifier().without_tag(),
+                AccessErrorKind::InvalidManifest(format!("'{}' is not a description companion", fetched.pinned)),
+            ),
+        )));
+    }
+    let warnings = std::mem::take(&mut fetched.warnings);
+
+    // The whole companion is bounded by the 8 MiB layer gate above, so a
+    // per-file limit of that size never truncates a member. An empty
+    // companion is rejected here (data error, 65) by the unpack guard.
+    let entries = wrap(unpack_tar_in_memory(&fetched.blob, FETCH_BLOB_SIZE_LIMIT))?;
+    let files = entries
+        .iter()
+        .map(|e| {
+            let (content, _truncated, encoding) = path_content(e)?;
+            Ok(DescriptionFile {
+                path: e.path.to_string_lossy().into_owned(),
+                size: e.size,
+                content,
+                encoding,
+            })
+        })
+        .collect::<anyhow::Result<Vec<_>>>()?;
+
+    if let Some(dir) = out {
+        // Reuse install's tar path guard (`safe_relative_path` inside
+        // `DefaultMaterializer`) rather than hand-rolling one. The kind/name
+        // are cosmetic here — the companion is a plain tar tree.
+        wrap(DefaultMaterializer.materialize(ArtifactKind::Skill, &fetched.name, &fetched.blob, dir))?;
+    }
+
+    Ok(DescriptionReport {
+        reference: fetched.identifier.to_string(),
+        digest: fetched.pinned.strip_advisory().digest().to_string(),
+        kind: crate::oci::description::DESC_KIND.to_string(),
+        files,
+        warnings,
+    })
+}
+
+/// Resolve `reference` (retargeted to the `__grimoire` companion tag when
+/// `description` is set) to a digest **without downloading** the manifest or
+/// any blob — the extension's cache probe. One resolve, one `{ref, digest}`.
+///
+/// The reported digest equals the full fetch's manifest digest, so a matching
+/// digest lets a consumer skip `describe` + `fetch` entirely.
+///
+/// # Errors
+///
+/// A missing reference (not-found, 79 — parity with `grim fetch`) or an
+/// offline-uncached miss (81); resolution/transport faults keep their own
+/// taxonomy.
+pub async fn resolve_digest_only(
+    scope: &FetchScope,
+    access: &Arc<dyn OciAccess>,
+    reference: &str,
+    description: bool,
+) -> anyhow::Result<DigestReport> {
+    let warnings = scope.warnings.clone();
+    let id = if description {
+        companion_reference(scope, reference)?
+    } else {
+        let id = wrap(crate::config::resolve_reference(
+            reference,
+            &scope.registries,
+            &scope.short_id_default,
+        ))?;
+        if id.tag().is_none() && id.digest().is_none() {
+            id.clone_with_tag("latest")
+        } else {
+            id
+        }
+    };
+
+    // `Resolve` (not `Query`), like `describe`: an offline-uncached ref
+    // surfaces `offline-blocked` (81) instead of a misleading not-found.
+    let digest = wrap(access.resolve_digest(&id, Operation::Resolve).await)?.ok_or_else(|| not_found(&id))?;
+    let pinned = PinnedIdentifier::try_from(id.clone_with_digest(digest))
+        .map_err(|e| anyhow!("resolved digest did not pin '{id}': {e}"))?;
+
+    Ok(DigestReport {
+        reference: id.to_string(),
+        digest: pinned.strip_advisory().digest().to_string(),
+        warnings,
+    })
+}
+
+/// Route a `grim fetch` invocation to the shape its flags select — the single
+/// seam both the CLI (`grim fetch`) and the MCP `grim_fetch` tool call so the
+/// three modes stay in lockstep. `out` (CLI-only; MCP passes `None`) unpacks a
+/// `--description` companion to disk.
+///
+/// - `digest_only` ⇒ a resolve-only [`DigestReport`] (composes with
+///   `description` — the companion tag is probed).
+/// - `description` ⇒ the [`DescriptionReport`] bundle; with a `path` it
+///   composes through the shared content core (returns that one member — a
+///   works-but-undocumented convenience).
+/// - otherwise ⇒ the shaped [`FetchReport`] content.
+///
+/// # Errors
+///
+/// See [`fetch_description`], [`resolve_digest_only`], and
+/// [`fetch_with_limit`].
+#[allow(clippy::too_many_arguments)]
+pub async fn fetch_outcome(
+    scope: &FetchScope,
+    access: &Arc<dyn OciAccess>,
+    reference: &str,
+    vendor: Option<&str>,
+    path: Option<&str>,
+    description: bool,
+    digest_only: bool,
+    out: Option<&Path>,
+    doc_limit: usize,
+) -> anyhow::Result<FetchOutcome> {
+    if digest_only {
+        return Ok(FetchOutcome::Digest(
+            resolve_digest_only(scope, access, reference, description).await?,
+        ));
+    }
+    if description {
+        if let Some(path) = path {
+            // `--path` composes through the shared content core: pull one
+            // companion member (works, not the documented contract).
+            let companion = companion_reference(scope, reference)?;
+            let report = fetch_with_limit(scope, access, &companion.to_string(), None, Some(path), doc_limit).await?;
+            return Ok(FetchOutcome::Content(Box::new(report)));
+        }
+        return Ok(FetchOutcome::Description(
+            fetch_description(scope, access, reference, out).await?,
+        ));
+    }
+    let report = fetch_with_limit(scope, access, reference, vendor, path, doc_limit).await?;
+    Ok(FetchOutcome::Content(Box::new(report)))
 }
 
 /// The `grim describe` report: manifest-level metadata for one artifact,
@@ -440,6 +787,11 @@ pub struct DescribeReport {
     pub title: Option<String>,
     /// `org.opencontainers.image.description`.
     pub description: Option<String>,
+    /// Whether the repository carries a description companion at its reserved
+    /// `__grimoire` tag (fetch it with `grim fetch <ref> --description`).
+    /// Always present — the consumer skips a blind probe. Named to avoid
+    /// colliding with the `description` text annotation above.
+    pub has_description: bool,
     /// `com.grimoire.summary`, the short catalog blurb.
     pub summary: Option<String>,
     /// `org.opencontainers.image.version`.
@@ -501,6 +853,12 @@ pub async fn describe_artifact(
     // Tag listing (no blob), sorted for a stable report. `None` (endpoint
     // absent / repo has no tags) degrades to an empty list, not an error.
     let mut tags = wrap(access.list_tags(&id.without_tag()).await)?.unwrap_or_default();
+    // Derive companion presence from the PRE-filter tag list — the reserved
+    // `__grimoire` tag is visible here, before it is hidden below. Zero extra
+    // network: the tag listing is already in hand.
+    let has_description = tags.iter().any(|t| t == crate::oci::description::DESC_TAG);
+    // Internal companions (`__grimoire`, …) are never user-facing tags.
+    tags.retain(|t| !crate::oci::description::is_internal_tag(t));
     tags.sort();
 
     // Resolve to a digest with `Resolve` (not `Query`): online it delegates
@@ -509,8 +867,7 @@ pub async fn describe_artifact(
     // surfaces `offline-blocked` (81) here rather than the `Query` path's
     // misleading "not found" — the ref may well exist, the network is just
     // unreachable.
-    let digest = wrap(access.resolve_digest(&id, Operation::Resolve).await)?
-        .ok_or_else(|| anyhow!("reference '{id}' not found on the registry"))?;
+    let digest = wrap(access.resolve_digest(&id, Operation::Resolve).await)?.ok_or_else(|| not_found(&id))?;
     let pinned = PinnedIdentifier::try_from(id.clone_with_digest(digest))
         .map_err(|e| anyhow!("resolved digest did not pin '{id}': {e}"))?;
 
@@ -529,6 +886,7 @@ pub async fn describe_artifact(
         name,
         title: get("org.opencontainers.image.title"),
         description: get("org.opencontainers.image.description"),
+        has_description,
         summary: get("com.grimoire.summary"),
         version: get("org.opencontainers.image.version"),
         license: get("org.opencontainers.image.licenses"),
@@ -855,6 +1213,180 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn fetch_description_companion_indexes_readme_lists_files_and_rejects_vendor() {
+        let tmp = tempfile::tempdir().unwrap();
+        let reg = MemoryRegistry::new();
+        let readme = b"# Repo\n\nWhat this repo ships.\n";
+        let logo: &[u8] = &[0x89, 0x50, 0x4e, 0x47, 0x00, 0xff];
+        let blob = tar_of(&[("README.md", readme.as_slice()), ("logo.png", logo)]);
+        // A description companion: kind "desc", published to the __grimoire tag.
+        publish(&reg, "test.registry/acme/skills/demo:__grimoire", "desc", &blob).await;
+        let (scope, access) = scope_and_access(&reg, tmp.path(), tmp.path());
+        let reference = "test.registry/acme/skills/demo:__grimoire";
+
+        // Default: the README.md index, with every file listed.
+        let report = fetch_with_limit(&scope, &access, reference, None, None, FETCH_DOC_SIZE_LIMIT)
+            .await
+            .expect("fetch desc");
+        assert_eq!(report.kind, "desc", "reported kind is 'desc', not the placeholder");
+        assert_eq!(report.content.as_bytes(), readme);
+        let files: Vec<&str> = report.files.iter().map(|f| f.path.as_str()).collect();
+        assert!(files.contains(&"README.md"), "files: {files:?}");
+        assert!(files.contains(&"logo.png"), "files: {files:?}");
+
+        // --path pulls an asset (binary → base64, same shape as a skill).
+        let asset = fetch_with_limit(&scope, &access, reference, None, Some("logo.png"), FETCH_DOC_SIZE_LIMIT)
+            .await
+            .expect("fetch desc path");
+        assert_eq!(asset.encoding.as_deref(), Some("base64"));
+        assert_eq!(BASE64.decode(asset.content.as_bytes()).unwrap(), logo);
+
+        // A description has no vendor projection.
+        let err = fetch_with_limit(&scope, &access, reference, Some("claude"), None, FETCH_DOC_SIZE_LIMIT)
+            .await
+            .expect_err("desc + vendor must error");
+        assert!(err.to_string().contains("no vendor projection"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn fetch_description_inlines_all_members_and_out_unpacks_the_tree() {
+        let tmp = tempfile::tempdir().unwrap();
+        let reg = MemoryRegistry::new();
+        let readme = b"# Repo\n\nWhat this repo ships.\n";
+        let logo: &[u8] = &[0x89, 0x50, 0x4e, 0x47, 0x00, 0xff];
+        let blob = tar_of(&[("README.md", readme.as_slice()), ("assets/logo.png", logo)]);
+        // Retarget happens off the ARTIFACT ref, so publish the companion at
+        // the reserved tag in the same repo.
+        publish(&reg, "test.registry/acme/skills/demo:__grimoire", "desc", &blob).await;
+        let (scope, access) = scope_and_access(&reg, tmp.path(), tmp.path());
+        let artifact_ref = "test.registry/acme/skills/demo:latest";
+
+        let out_dir = tmp.path().join("unpacked");
+        let report = fetch_description(&scope, &access, artifact_ref, Some(&out_dir))
+            .await
+            .expect("fetch description");
+
+        assert_eq!(report.kind, "desc");
+        assert!(
+            report.reference.ends_with(":__grimoire"),
+            "companion ref: {}",
+            report.reference
+        );
+        assert!(report.digest.starts_with("sha256:"));
+        // Every member inline, sorted by path: text verbatim, binary base64.
+        let readme_file = report
+            .files
+            .iter()
+            .find(|f| f.path == "README.md")
+            .expect("README member");
+        assert_eq!(readme_file.content.as_bytes(), readme);
+        assert!(readme_file.encoding.is_none(), "text member carries no encoding");
+        let logo_file = report
+            .files
+            .iter()
+            .find(|f| f.path == "assets/logo.png")
+            .expect("logo member");
+        assert_eq!(logo_file.encoding.as_deref(), Some("base64"));
+        assert_eq!(BASE64.decode(logo_file.content.as_bytes()).unwrap(), logo);
+
+        // --out unpacked the tree through install's guard.
+        assert_eq!(std::fs::read(out_dir.join("README.md")).unwrap(), readme);
+        assert_eq!(std::fs::read(out_dir.join("assets/logo.png")).unwrap(), logo);
+    }
+
+    #[tokio::test]
+    async fn fetch_description_missing_companion_classifies_not_found() {
+        let tmp = tempfile::tempdir().unwrap();
+        let reg = MemoryRegistry::new();
+        // An artifact with no companion at the __grimoire tag.
+        publish(
+            &reg,
+            "test.registry/acme/skills/lonely:latest",
+            "skill",
+            &tar_of(&[("lonely/SKILL.md", b"# x\n")]),
+        )
+        .await;
+        let (scope, access) = scope_and_access(&reg, tmp.path(), tmp.path());
+
+        let err = fetch_description(&scope, &access, "test.registry/acme/skills/lonely:latest", None)
+            .await
+            .expect_err("missing companion must error");
+        assert_eq!(
+            crate::error::classify_error(&err),
+            crate::cli::exit_code::ExitCode::NotFound,
+            "a missing companion is not-found (79), parity with grim fetch"
+        );
+    }
+
+    #[tokio::test]
+    async fn digest_only_matches_full_fetch_digest_for_artifact_and_companion() {
+        let tmp = tempfile::tempdir().unwrap();
+        let reg = MemoryRegistry::new();
+        let skill = tar_of(&[("demo/SKILL.md", b"---\nname: demo\ndescription: d\n---\n# d\n")]);
+        publish(&reg, "test.registry/acme/skills/demo:latest", "skill", &skill).await;
+        let companion = tar_of(&[("README.md", b"# Repo\n")]);
+        publish(&reg, "test.registry/acme/skills/demo:__grimoire", "desc", &companion).await;
+        let (scope, access) = scope_and_access(&reg, tmp.path(), tmp.path());
+        let reference = "test.registry/acme/skills/demo:latest";
+
+        // Artifact: the probe digest equals the full fetch's digest.
+        let full = fetch_with_limit(&scope, &access, reference, None, None, FETCH_DOC_SIZE_LIMIT)
+            .await
+            .expect("full fetch");
+        let probe = resolve_digest_only(&scope, &access, reference, false)
+            .await
+            .expect("digest probe");
+        assert_eq!(probe.digest, full.digest, "artifact probe digest == full fetch digest");
+        assert!(!probe.reference.ends_with(":__grimoire"));
+
+        // Companion: the probe digest equals the description bundle's digest.
+        let desc = fetch_description(&scope, &access, reference, None)
+            .await
+            .expect("fetch description");
+        let desc_probe = resolve_digest_only(&scope, &access, reference, true)
+            .await
+            .expect("companion digest probe");
+        assert_eq!(
+            desc_probe.digest, desc.digest,
+            "companion probe digest == companion fetch digest"
+        );
+        assert!(desc_probe.reference.ends_with(":__grimoire"));
+        assert_ne!(
+            probe.digest, desc_probe.digest,
+            "artifact and companion are distinct manifests"
+        );
+    }
+
+    #[tokio::test]
+    async fn describe_hides_internal_desc_tag_from_tags_list() {
+        let tmp = tempfile::tempdir().unwrap();
+        let reg = MemoryRegistry::new();
+        // A real artifact whose repo also carries the internal __grimoire tag.
+        publish_annotated(
+            &reg,
+            "test.registry/acme/skills/demo:latest",
+            &[(KIND_ANNOTATION, "skill")],
+            &["1.0.0", "__grimoire"],
+        )
+        .await;
+        let (scope, access) = scope_and_access(&reg, tmp.path(), tmp.path());
+
+        let d = describe_artifact(&scope, &access, "test.registry/acme/skills/demo:latest")
+            .await
+            .expect("describe");
+        assert!(
+            !d.tags.iter().any(|t| t == "__grimoire"),
+            "internal tag must be hidden from describe tags[], got {:?}",
+            d.tags
+        );
+        assert_eq!(d.tags, vec!["1.0.0", "latest"], "only user-facing tags remain, sorted");
+        assert!(
+            d.has_description,
+            "the __grimoire companion tag is present ⇒ has_description"
+        );
+    }
+
+    #[tokio::test]
     async fn fetch_bundle_rejects_vendor_and_oversize_layer_gates() {
         let tmp = tempfile::tempdir().unwrap();
         let reg = MemoryRegistry::new();
@@ -1029,6 +1561,10 @@ mod tests {
         assert_eq!(d.deprecated.as_deref(), Some("use acme/demo-2"));
         assert_eq!(d.replaced_by.as_deref(), Some("ghcr.io/acme/skills/demo-2"));
         assert_eq!(d.tags, vec!["1.0.0", "1.2.0", "latest"], "tags sorted");
+        assert!(
+            !d.has_description,
+            "no __grimoire companion tag ⇒ has_description false"
+        );
         assert!(d.digest.starts_with("sha256:"));
         // The verbatim annotation map is carried whole.
         assert_eq!(d.annotations["com.grimoire.replaced-by"], "ghcr.io/acme/skills/demo-2");

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -28,10 +28,13 @@
 //! `grim_render` / `grim install` as the escape hatch (a truncated doc is
 //! still useful in-context).
 
+use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 
 use anyhow::anyhow;
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD as BASE64;
 use serde::Serialize;
 
 use crate::config::ResolvedRegistry;
@@ -123,8 +126,8 @@ pub struct FetchFileEntry {
 /// The `grim_fetch` tool result payload.
 ///
 /// JSON format: `{ref, digest, kind, name, vendor, path?, content,
-/// truncated?, files?, pointer?, warnings?}` — empty/default fields are
-/// omitted.
+/// encoding?, truncated?, files?, pointer?, warnings?}` — empty/default
+/// fields are omitted.
 #[derive(Debug, Serialize)]
 pub struct FetchReport {
     /// The fully-qualified resolved reference.
@@ -141,8 +144,14 @@ pub struct FetchReport {
     /// The support-file path when one was requested.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub path: Option<String>,
-    /// The document content (canonical or projected).
+    /// The document content (canonical or projected), or the base64 of a
+    /// binary support file when [`Self::encoding`] is `"base64"`.
     pub content: String,
+    /// `"base64"` when [`Self::content`] is the base64 of a non-UTF-8
+    /// `--path` support file; omitted (UTF-8 text) otherwise. Plain mode
+    /// decodes it back to the raw bytes so a redirect round-trips.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub encoding: Option<String>,
     /// Whether `content` was truncated at [`FETCH_DOC_SIZE_LIMIT`].
     #[serde(skip_serializing_if = "std::ops::Not::not")]
     pub truncated: bool,
@@ -290,6 +299,7 @@ pub async fn fetch_with_limit(
         vendor: vendor_client.map_or_else(|| "canonical".to_string(), |v| v.as_str().to_string()),
         path: path.map(str::to_string),
         content: String::new(),
+        encoding: None,
         truncated: false,
         files: Vec::new(),
         pointer: None,
@@ -313,14 +323,16 @@ pub async fn fetch_with_limit(
             };
 
             if let Some(path) = path {
-                // One support file, exact bytes (UTF-8 required).
+                // One support file: UTF-8 text verbatim, or base64 for a
+                // non-UTF-8 (binary) file within the size limit.
                 let entry = entries
                     .iter()
                     .find(|e| e.path == std::path::Path::new(path))
                     .ok_or_else(|| anyhow!("no file '{path}' in this artifact (see the files listing)"))?;
-                let (content, truncated) = entry_content(entry)?;
+                let (content, truncated, encoding) = path_content(entry)?;
                 report.content = content;
                 report.truncated = truncated;
+                report.encoding = encoding;
             } else {
                 let index = entries
                     .iter()
@@ -386,17 +398,159 @@ pub async fn fetch_with_limit(
     }
 
     // Cap whatever content shape was produced (vendor projections and
-    // descriptor documents can exceed the per-entry cap path).
-    let (content, capped) = cap_content(std::mem::take(&mut report.content), doc_limit);
-    report.content = content;
-    if capped {
-        report.truncated = true;
-    }
-    if report.truncated && !report.content.ends_with(TRUNCATION_MARKER) {
-        report.content.push_str(TRUNCATION_MARKER);
+    // descriptor documents can exceed the per-entry cap path). Base64
+    // content is never capped: a truncated base64 payload can't decode back
+    // to the original bytes, so an oversize binary errors upstream instead.
+    if report.encoding.is_none() {
+        let (content, capped) = cap_content(std::mem::take(&mut report.content), doc_limit);
+        report.content = content;
+        if capped {
+            report.truncated = true;
+        }
+        if report.truncated && !report.content.ends_with(TRUNCATION_MARKER) {
+            report.content.push_str(TRUNCATION_MARKER);
+        }
     }
     report.warnings = warnings;
     Ok(report)
+}
+
+/// The `grim describe` report: manifest-level metadata for one artifact,
+/// read without downloading the content layer.
+///
+/// A **single-object report** under the [null policy][crate]: every field is
+/// always present, serializing as an explicit `null` when absent. The two
+/// collection fields are the empty-collection form of that policy —
+/// `keywords`/`tags` are `[]` when none (mirroring `grim context`'s
+/// always-present arrays), and `annotations` is the verbatim manifest
+/// annotation map (`{}` when empty).
+#[derive(Debug, Serialize)]
+pub struct DescribeReport {
+    /// The fully-qualified resolved reference.
+    #[serde(rename = "ref")]
+    pub reference: String,
+    /// The resolved manifest digest.
+    pub digest: String,
+    /// The artifact kind, or `null` for a foreign / non-Grimoire manifest
+    /// (describe never hard-errors on one).
+    pub kind: Option<String>,
+    /// The artifact name (the reference's last path segment).
+    pub name: String,
+    /// `org.opencontainers.image.title`.
+    pub title: Option<String>,
+    /// `org.opencontainers.image.description`.
+    pub description: Option<String>,
+    /// `com.grimoire.summary`, the short catalog blurb.
+    pub summary: Option<String>,
+    /// `org.opencontainers.image.version`.
+    pub version: Option<String>,
+    /// `org.opencontainers.image.licenses`.
+    pub license: Option<String>,
+    /// `org.opencontainers.image.source`, kept only when it is an HTTPS
+    /// repository URL (same guard as `grim search`).
+    pub repository: Option<String>,
+    /// `org.opencontainers.image.revision` (the `--git` publish opt-in).
+    pub revision: Option<String>,
+    /// `org.opencontainers.image.created` (the `--git` publish opt-in).
+    pub created: Option<String>,
+    /// `com.grimoire.keywords` split on commas (trimmed, empties dropped);
+    /// `[]` when none.
+    pub keywords: Vec<String>,
+    /// The `com.grimoire.deprecated` message, or `null` when not deprecated.
+    pub deprecated: Option<String>,
+    /// The `com.grimoire.replaced-by` successor reference, or `null`.
+    pub replaced_by: Option<String>,
+    /// Every tag on the repository, sorted; `[]` when none / unavailable.
+    pub tags: Vec<String>,
+    /// The verbatim manifest annotation map.
+    pub annotations: BTreeMap<String, String>,
+}
+
+/// Resolve `reference` and read its manifest-level metadata — kind, curated
+/// annotations, and tags — **without downloading the content layer**. Powers
+/// the `grim describe` CLI and the MCP `grim_describe` tool.
+///
+/// Sequence: list the repository's tags, resolve the reference to a digest
+/// (a missing repository errors with the same message as `grim fetch`), then
+/// read the manifest annotations. A foreign / non-Grimoire manifest does NOT
+/// hard-error — its `kind` is `null` and the curated fields fall to their
+/// absent values.
+///
+/// # Errors
+///
+/// Reference parse failures, resolution/transport faults (their own
+/// taxonomy: offline 81, auth 80, unreachable 69, …), or a missing tag or
+/// manifest.
+pub async fn describe_artifact(
+    scope: &FetchScope,
+    access: &Arc<dyn OciAccess>,
+    reference: &str,
+) -> anyhow::Result<DescribeReport> {
+    let id = wrap(crate::config::resolve_reference(
+        reference,
+        &scope.registries,
+        &scope.short_id_default,
+    ))?;
+    let id = if id.tag().is_none() && id.digest().is_none() {
+        id.clone_with_tag("latest")
+    } else {
+        id
+    };
+    let name = id.name().to_string();
+
+    // Tag listing (no blob), sorted for a stable report. `None` (endpoint
+    // absent / repo has no tags) degrades to an empty list, not an error.
+    let mut tags = wrap(access.list_tags(&id.without_tag()).await)?.unwrap_or_default();
+    tags.sort();
+
+    // Resolve to a digest with `Resolve` (not `Query`): online it delegates
+    // identically, so a genuinely missing repository still errors with
+    // fetch's "not found" message (error parity). Offline, an uncached ref
+    // surfaces `offline-blocked` (81) here rather than the `Query` path's
+    // misleading "not found" — the ref may well exist, the network is just
+    // unreachable.
+    let digest = wrap(access.resolve_digest(&id, Operation::Resolve).await)?
+        .ok_or_else(|| anyhow!("reference '{id}' not found on the registry"))?;
+    let pinned = PinnedIdentifier::try_from(id.clone_with_digest(digest))
+        .map_err(|e| anyhow!("resolved digest did not pin '{id}': {e}"))?;
+
+    let manifest = wrap(access.fetch_manifest(&pinned).await)?
+        .ok_or_else(|| anyhow!("manifest for '{pinned}' not found on the registry"))?;
+
+    let a = &manifest.annotations;
+    let get = |k: &str| a.get(k).cloned();
+    let keywords = a
+        .get("com.grimoire.keywords")
+        .map(|k| {
+            k.split(',')
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(str::to_string)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+
+    Ok(DescribeReport {
+        reference: id.to_string(),
+        digest: pinned.strip_advisory().digest().to_string(),
+        // A foreign manifest yields `None` here rather than erroring.
+        kind: crate::oci::annotations::kind_from_manifest(&manifest).map(|k| k.to_string()),
+        name,
+        title: get("org.opencontainers.image.title"),
+        description: get("org.opencontainers.image.description"),
+        summary: get("com.grimoire.summary"),
+        version: get("org.opencontainers.image.version"),
+        license: get("org.opencontainers.image.licenses"),
+        // Same HTTPS guard as search: older artifacts carry a release ref here.
+        repository: get("org.opencontainers.image.source").filter(|s| s.starts_with("https://")),
+        revision: get("org.opencontainers.image.revision"),
+        created: get("org.opencontainers.image.created"),
+        keywords,
+        deprecated: crate::oci::annotations::deprecation_message(a),
+        replaced_by: crate::oci::annotations::replacement_ref(a),
+        tags,
+        annotations: a.clone(),
+    })
 }
 
 /// Project the index document for `client`; `Ok(None)` when the canonical
@@ -459,6 +613,40 @@ fn entry_content(entry: &TarEntryData) -> anyhow::Result<(String, bool)> {
             "'{}' is not UTF-8 text; use grim_render to write it to disk instead",
             entry.path.display()
         )),
+    }
+}
+
+/// Shape a `--path` support file: UTF-8 text verbatim, or base64 for a
+/// non-UTF-8 (binary) file that fits within the size limit. Returns
+/// `(content, truncated, encoding)` where `encoding` is `Some("base64")`
+/// only for the binary case.
+///
+/// A binary file large enough to be truncated by the layer/doc cap keeps
+/// erroring: a base64 of a prefix can't round-trip back to the original
+/// bytes, so partial binaries are refused rather than silently corrupted.
+///
+/// # Errors
+///
+/// A non-UTF-8 file that exceeds the size limit (its bytes were truncated).
+fn path_content(entry: &TarEntryData) -> anyhow::Result<(String, bool, Option<String>)> {
+    match std::str::from_utf8(&entry.bytes) {
+        Ok(s) => Ok((s.to_string(), entry.truncated, None)),
+        // The cap cut a multi-byte character mid-code-point; the valid
+        // prefix is text (matches `entry_content`'s tolerance).
+        Err(e) if entry.truncated && entry.bytes.len() - e.valid_up_to() < 4 => Ok((
+            String::from_utf8_lossy(&entry.bytes[..e.valid_up_to()]).into_owned(),
+            true,
+            None,
+        )),
+        // A truncated (oversize) binary can't round-trip from a prefix.
+        Err(_) if entry.truncated => Err(anyhow!(
+            "'{}' is binary and exceeds the {}-byte size limit; use grim install to write it to disk",
+            entry.path.display(),
+            FETCH_DOC_SIZE_LIMIT
+        )),
+        // Non-UTF-8 within the size limit: base64 the exact bytes so a plain
+        // `grim fetch … --path x > file` redirect round-trips byte-identical.
+        Err(_) => Ok((BASE64.encode(&entry.bytes), false, Some("base64".to_string()))),
     }
 }
 
@@ -773,6 +961,110 @@ mod tests {
         assert_eq!(full.content, body);
     }
 
+    /// Push a single-layer artifact carrying `annotations`, tagged `latest`
+    /// plus any `extra_tags`, so the describe read path sees a real manifest
+    /// and tag list.
+    async fn publish_annotated(
+        reg: &MemoryRegistry,
+        reference: &str,
+        annotations: &[(&str, &str)],
+        extra_tags: &[&str],
+    ) {
+        use crate::oci::access::OciAccess as _;
+        let id = Identifier::parse(reference).unwrap();
+        let blob = tar_of(&[("x/SKILL.md", b"# x\n")]);
+        let digest = reg.push_blob(&id, &blob).await.unwrap();
+        let manifest = OciManifest {
+            media_type: None,
+            artifact_type: None,
+            config_media_type: None,
+            layers: vec![Descriptor {
+                digest,
+                media_type: "application/vnd.grimoire.content.v1.tar".to_string(),
+                size: blob.len() as u64,
+            }],
+            annotations: annotations
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect(),
+        };
+        let mdigest = reg.push_manifest(&id, &manifest).await.unwrap();
+        reg.put_tag(&id, "latest", &mdigest).await.unwrap();
+        for tag in extra_tags {
+            reg.put_tag(&id, tag, &mdigest).await.unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn describe_reports_all_curated_fields_and_sorted_tags() {
+        let tmp = tempfile::tempdir().unwrap();
+        let reg = MemoryRegistry::new();
+        publish_annotated(
+            &reg,
+            "test.registry/acme/skills/demo:latest",
+            &[
+                (KIND_ANNOTATION, "skill"),
+                ("org.opencontainers.image.title", "demo"),
+                ("org.opencontainers.image.description", "Demo skill."),
+                ("com.grimoire.summary", "terse blurb"),
+                ("org.opencontainers.image.version", "1.2.0"),
+                ("org.opencontainers.image.licenses", "Apache-2.0"),
+                ("org.opencontainers.image.source", "https://github.com/acme/demo"),
+                ("org.opencontainers.image.revision", "abc123-dirty"),
+                ("org.opencontainers.image.created", "2026-06-29T12:00:00+00:00"),
+                ("com.grimoire.keywords", "review, quality"),
+                ("com.grimoire.deprecated", "use acme/demo-2"),
+                ("com.grimoire.replaced-by", "ghcr.io/acme/skills/demo-2"),
+            ],
+            &["1.2.0", "1.0.0"],
+        )
+        .await;
+        let (scope, access) = scope_and_access(&reg, tmp.path(), tmp.path());
+
+        let d = describe_artifact(&scope, &access, "test.registry/acme/skills/demo:latest")
+            .await
+            .expect("describe");
+        assert_eq!(d.kind.as_deref(), Some("skill"));
+        assert_eq!(d.name, "demo");
+        assert_eq!(d.title.as_deref(), Some("demo"));
+        assert_eq!(d.description.as_deref(), Some("Demo skill."));
+        assert_eq!(d.summary.as_deref(), Some("terse blurb"));
+        assert_eq!(d.version.as_deref(), Some("1.2.0"));
+        assert_eq!(d.license.as_deref(), Some("Apache-2.0"));
+        assert_eq!(d.repository.as_deref(), Some("https://github.com/acme/demo"));
+        assert_eq!(d.revision.as_deref(), Some("abc123-dirty"));
+        assert_eq!(d.created.as_deref(), Some("2026-06-29T12:00:00+00:00"));
+        assert_eq!(d.keywords, vec!["review", "quality"], "split + trimmed");
+        assert_eq!(d.deprecated.as_deref(), Some("use acme/demo-2"));
+        assert_eq!(d.replaced_by.as_deref(), Some("ghcr.io/acme/skills/demo-2"));
+        assert_eq!(d.tags, vec!["1.0.0", "1.2.0", "latest"], "tags sorted");
+        assert!(d.digest.starts_with("sha256:"));
+        // The verbatim annotation map is carried whole.
+        assert_eq!(d.annotations["com.grimoire.replaced-by"], "ghcr.io/acme/skills/demo-2");
+    }
+
+    #[tokio::test]
+    async fn describe_bare_foreign_manifest_nulls_kind_not_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let reg = MemoryRegistry::new();
+        // No grimoire/OCI annotations at all — a foreign manifest.
+        publish_annotated(&reg, "test.registry/acme/misc/foreign:latest", &[], &[]).await;
+        let (scope, access) = scope_and_access(&reg, tmp.path(), tmp.path());
+
+        let d = describe_artifact(&scope, &access, "test.registry/acme/misc/foreign:latest")
+            .await
+            .expect("describe must not hard-error on a foreign manifest");
+        assert!(d.kind.is_none(), "foreign manifest ⇒ null kind");
+        assert!(d.title.is_none());
+        assert!(d.description.is_none());
+        assert!(d.summary.is_none());
+        assert!(d.deprecated.is_none());
+        assert!(d.replaced_by.is_none());
+        assert!(d.keywords.is_empty(), "no keywords ⇒ empty array");
+        assert_eq!(d.tags, vec!["latest"]);
+        assert_eq!(d.name, "foreign");
+    }
+
     #[test]
     fn cap_content_is_char_boundary_safe() {
         // A multi-byte char straddling the cap must not split.
@@ -786,6 +1078,75 @@ mod tests {
         let (untouched, truncated) = cap_content("short".to_string(), FETCH_DOC_SIZE_LIMIT);
         assert!(!truncated);
         assert_eq!(untouched, "short");
+    }
+
+    #[tokio::test]
+    async fn fetch_path_base64_encodes_binary_and_round_trips() {
+        let tmp = tempfile::tempdir().unwrap();
+        let reg = MemoryRegistry::new();
+        // A non-UTF-8 (PNG-signature) support file rides the layer tree.
+        let logo: &[u8] = &[0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0xff, 0xfe];
+        let blob = tar_of(&[("demo/SKILL.md", b"# d\n"), ("demo/assets/logo.png", logo)]);
+        publish(&reg, "test.registry/acme/skills/demo:latest", "skill", &blob).await;
+        let (scope, access) = scope_and_access(&reg, tmp.path(), tmp.path());
+
+        let report = fetch_with_limit(
+            &scope,
+            &access,
+            "test.registry/acme/skills/demo:latest",
+            None,
+            Some("demo/assets/logo.png"),
+            FETCH_DOC_SIZE_LIMIT,
+        )
+        .await
+        .expect("fetch binary path");
+        assert_eq!(report.encoding.as_deref(), Some("base64"));
+        assert!(!report.truncated);
+        // The content is the base64 of the exact bytes and decodes back.
+        assert_eq!(report.content, BASE64.encode(logo));
+        assert_eq!(BASE64.decode(report.content.as_bytes()).unwrap(), logo);
+
+        // A UTF-8 support file is unchanged (no encoding field).
+        let text = fetch_with_limit(
+            &scope,
+            &access,
+            "test.registry/acme/skills/demo:latest",
+            None,
+            Some("demo/SKILL.md"),
+            FETCH_DOC_SIZE_LIMIT,
+        )
+        .await
+        .expect("fetch text path");
+        assert_eq!(text.content, "# d\n");
+        assert!(text.encoding.is_none(), "UTF-8 content carries no encoding field");
+    }
+
+    #[test]
+    fn path_content_errors_on_oversize_binary_and_keeps_text_prefix() {
+        // A truncated (oversize) binary is refused — a base64 of a prefix
+        // would not round-trip.
+        // A leading invalid start byte with a long invalid tail (not a cut
+        // multi-byte char), so it is classified as binary, not truncated text.
+        let binary = TarEntryData {
+            path: PathBuf::from("big.bin"),
+            size: FETCH_DOC_SIZE_LIMIT as u64 * 2,
+            bytes: vec![0xff, 0xfe, 0xfd, 0xfc, 0xfb, 0xfa],
+            truncated: true,
+        };
+        let err = path_content(&binary).expect_err("oversize binary must error");
+        assert!(err.to_string().contains("exceeds"), "{err}");
+
+        // A non-truncated binary within the limit base64-encodes.
+        let ok = TarEntryData {
+            path: PathBuf::from("logo.png"),
+            size: 3,
+            bytes: vec![0x89, 0x50, 0x4e],
+            truncated: false,
+        };
+        let (content, truncated, encoding) = path_content(&ok).expect("binary within limit");
+        assert_eq!(encoding.as_deref(), Some("base64"));
+        assert!(!truncated);
+        assert_eq!(BASE64.decode(content.as_bytes()).unwrap(), vec![0x89, 0x50, 0x4e]);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,7 +60,7 @@ use crate::command::status::StatusArgs;
 use crate::command::tui::TuiArgs;
 use crate::command::uninstall::UninstallArgs;
 use crate::command::update::UpdateArgs;
-use crate::error::classify_error;
+use crate::error::{classify_error, classify_reason};
 
 #[derive(Parser)]
 #[command(
@@ -154,6 +154,7 @@ fn main() -> std::process::ExitCode {
                 format,
                 ExitCode::Failure,
                 &format!("failed to start async runtime: {err}"),
+                None,
             );
             return ExitCode::Failure.into();
         }
@@ -167,33 +168,43 @@ fn main() -> std::process::ExitCode {
             // the default filter also writes to stderr).
             eprintln!("{err:#}");
             let code = classify_error(&err);
-            emit_error_document(format, code, &format!("{err:#}"));
+            emit_error_document(format, code, &format!("{err:#}"), classify_reason(&err));
             code.into()
         }
     }
 }
 
 /// Under `--format json`, print the structured error document to stdout:
-/// `{"error": {"code": "<slug>", "exit": <int>, "message": "<chain>"}}`.
+/// `{"error": {"code": "<slug>", "exit": <int>, "message": "<chain>", "reason"?}}`.
 ///
 /// stdout — not stderr — because stderr carries tracing output and the two
 /// would interleave; a consumer parses stdout and treats a top-level
 /// `error` key as the error document (see `docs/src/json-interface.md`).
 /// Plain mode emits nothing here (the human chain is already on stderr).
-fn emit_error_document(format: OutputFormat, code: ExitCode, message: &str) {
+fn emit_error_document(format: OutputFormat, code: ExitCode, message: &str, reason: Option<&str>) {
     if format != OutputFormat::Json {
         return;
     }
-    let doc = serde_json::json!({
-        "error": {
-            "code": code.slug(),
-            "exit": code as u8,
-            "message": message,
-        }
-    });
-    if let Ok(rendered) = serde_json::to_string_pretty(&doc) {
+    if let Ok(rendered) = serde_json::to_string_pretty(&error_document(code, message, reason)) {
         println!("{rendered}");
     }
+}
+
+/// Build the error-document value. `reason` is the optional machine-readable
+/// subtype (`classify_reason`); when `None` the key is omitted, matching the
+/// fetch `encoding` omit-empty precedent so a consumer distinguishes an old
+/// grim (no key) from an unclassified error (still no key — the same, by
+/// design: reasons are purely additive over the existing `code`/`exit`).
+fn error_document(code: ExitCode, message: &str, reason: Option<&str>) -> serde_json::Value {
+    let mut error = serde_json::json!({
+        "code": code.slug(),
+        "exit": code as u8,
+        "message": message,
+    });
+    if let Some(reason) = reason {
+        error["reason"] = serde_json::Value::String(reason.to_string());
+    }
+    serde_json::json!({ "error": error })
 }
 
 /// Initialize tracing from the `GRIM_LOG` env var (falls back to `warn`).
@@ -224,4 +235,25 @@ fn init_tracing() {
                 .with_filter(filter),
         )
         .try_init();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn error_document_omits_reason_when_absent() {
+        let doc = error_document(ExitCode::DataError, "boom", None);
+        let error = &doc["error"];
+        assert_eq!(error["code"], "data");
+        assert_eq!(error["exit"], 65);
+        assert_eq!(error["message"], "boom");
+        assert!(error.get("reason").is_none(), "absent reason must omit the key: {doc}");
+    }
+
+    #[test]
+    fn error_document_carries_reason_when_present() {
+        let doc = error_document(ExitCode::DataError, "boom", Some("stale-lock"));
+        assert_eq!(doc["error"]["reason"], "stale-lock");
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,7 +60,7 @@ use crate::command::status::StatusArgs;
 use crate::command::tui::TuiArgs;
 use crate::command::uninstall::UninstallArgs;
 use crate::command::update::UpdateArgs;
-use crate::error::{classify_error, classify_reason};
+use crate::error::classify;
 
 #[derive(Parser)]
 #[command(
@@ -167,9 +167,10 @@ fn main() -> std::process::ExitCode {
             // stderr (a `tracing::error!` here would duplicate the line —
             // the default filter also writes to stderr).
             eprintln!("{err:#}");
-            let code = classify_error(&err);
-            emit_error_document(format, code, &format!("{err:#}"), classify_reason(&err));
-            code.into()
+            let classification = classify(&err);
+            let reason = classification.reason.map(|r| r.to_string());
+            emit_error_document(format, classification.exit, &format!("{err:#}"), reason.as_deref());
+            classification.exit.into()
         }
     }
 }
@@ -191,10 +192,11 @@ fn emit_error_document(format: OutputFormat, code: ExitCode, message: &str, reas
 }
 
 /// Build the error-document value. `reason` is the optional machine-readable
-/// subtype (`classify_reason`); when `None` the key is omitted, matching the
-/// fetch `encoding` omit-empty precedent so a consumer distinguishes an old
-/// grim (no key) from an unclassified error (still no key — the same, by
-/// design: reasons are purely additive over the existing `code`/`exit`).
+/// subtype (`error::classify`'s `Classification::reason`, rendered via its
+/// `Display`); when `None` the key is omitted, matching the fetch `encoding`
+/// omit-empty precedent so a consumer distinguishes an old grim (no key)
+/// from an unclassified error (still no key — the same, by design: reasons
+/// are purely additive over the existing `code`/`exit`).
 fn error_document(code: ExitCode, message: &str, reason: Option<&str>) -> serde_json::Value {
     let mut error = serde_json::json!({
         "code": code.slug(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,6 +43,7 @@ use crate::command::add::AddArgs;
 use crate::command::build::BuildArgs;
 use crate::command::config::ConfigArgs;
 use crate::command::context::ContextArgs;
+use crate::command::describe::DescribeArgs;
 use crate::command::fetch::FetchArgs;
 use crate::command::init::InitArgs;
 use crate::command::install::InstallArgs;
@@ -109,6 +110,9 @@ pub enum Command {
     Search(SearchArgs),
     /// Print an artifact's content without installing it.
     Fetch(FetchArgs),
+    /// Report an artifact's metadata (kind, annotations, tags) without
+    /// downloading its content.
+    Describe(DescribeArgs),
     /// Print the JSON Schema for grimoire.toml or publish.toml.
     Schema(SchemaArgs),
     /// Browse the registry catalog in an interactive TUI.

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -10,6 +10,7 @@
 //! scope is a per-tool-call parameter (`global` / `config` / `workspace`) —
 //! see `adr_mcp_percall_scope_fetch_render.md`.
 
+pub mod describe;
 pub mod fetch;
 pub mod render;
 pub mod server;

--- a/src/mcp/describe.rs
+++ b/src/mcp/describe.rs
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The Grimoire Authors
+
+//! The `grim_describe` tool: a thin MCP adapter over the neutral describe
+//! core ([`crate::fetch::describe_artifact`]).
+//!
+//! It resolves the per-call scope + access seam from the MCP argument trio
+//! (`global`/`config`/`workspace`) and delegates to
+//! [`crate::fetch::describe_artifact`], which reports manifest-level metadata
+//! (kind, curated annotations, tags) without downloading the content layer.
+//! The payload equals `grim describe --format json` modulo whitespace.
+
+use crate::context::Context;
+
+use super::tool_args::DescribeToolArgs;
+
+/// Run the `grim_describe` tool: resolve scope + access, then read the
+/// artifact's manifest-level metadata.
+///
+/// # Errors
+///
+/// See [`crate::fetch::describe_artifact`].
+pub async fn describe(ctx: &Context, args: &DescribeToolArgs) -> anyhow::Result<crate::fetch::DescribeReport> {
+    let scope = crate::command::resolve_fetch_scope(
+        ctx,
+        args.scope.global(),
+        args.scope.config.as_deref(),
+        args.scope.workspace.as_deref(),
+    );
+    let access = crate::command::access_seam(ctx)?;
+    crate::fetch::describe_artifact(&scope, &access, &args.reference).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn describe_args_ref_rename_and_unknown_key_tolerance() {
+        let args: DescribeToolArgs =
+            serde_json::from_str(r#"{"ref": "skills/x", "global": true, "ignored": true}"#).unwrap();
+        assert_eq!(args.reference, "skills/x");
+        assert!(args.scope.global());
+    }
+}

--- a/src/mcp/fetch.rs
+++ b/src/mcp/fetch.rs
@@ -6,23 +6,26 @@
 //!
 //! It resolves the per-call scope + access seam from the MCP argument trio
 //! (`global`/`config`/`workspace`) and delegates to
-//! [`crate::fetch::fetch_with_limit`] with the 256 KiB tool-result document
-//! cap. All content-shaping, size gating, and truncation live in the core;
-//! this file only bridges the MCP argument type to it.
+//! [`crate::fetch::fetch_outcome`] with the 256 KiB tool-result document cap.
+//! The `description` / `digest_only` args select the same three shapes the
+//! CLI does (content / companion bundle / digest probe); writes stay in
+//! `grim_render`, so no `out` is threaded. All content-shaping, size gating,
+//! and truncation live in the core; this file only bridges the MCP argument
+//! type to it.
 
 use crate::context::Context;
 
 use super::tool_args::FetchToolArgs;
 
-/// Run the `grim_fetch` tool: resolve scope + access, then fetch and shape
-/// the artifact content. Documents cap at
-/// [`crate::fetch::FETCH_DOC_SIZE_LIMIT`] (a truncated doc is still useful
-/// in a tool result).
+/// Run the `grim_fetch` tool: resolve scope + access, then fetch the shape the
+/// flags select. Documents cap at [`crate::fetch::FETCH_DOC_SIZE_LIMIT`] (a
+/// truncated doc is still useful in a tool result); a `description` companion
+/// is bounded by the 8 MiB layer gate instead, with no per-file truncation.
 ///
 /// # Errors
 ///
-/// See [`crate::fetch::fetch_with_limit`].
-pub async fn fetch(ctx: &Context, args: &FetchToolArgs) -> anyhow::Result<crate::fetch::FetchReport> {
+/// See [`crate::fetch::fetch_outcome`].
+pub async fn fetch(ctx: &Context, args: &FetchToolArgs) -> anyhow::Result<crate::fetch::FetchOutcome> {
     let scope = crate::command::resolve_fetch_scope(
         ctx,
         args.scope.global(),
@@ -30,12 +33,16 @@ pub async fn fetch(ctx: &Context, args: &FetchToolArgs) -> anyhow::Result<crate:
         args.scope.workspace.as_deref(),
     );
     let access = crate::command::access_seam(ctx)?;
-    crate::fetch::fetch_with_limit(
+    crate::fetch::fetch_outcome(
         &scope,
         &access,
         &args.reference,
         args.vendor.as_deref(),
         args.path.as_deref(),
+        args.description.unwrap_or(false),
+        args.digest_only.unwrap_or(false),
+        // Writes stay in `grim_render` — the fetch tool never touches disk.
+        None,
         crate::fetch::FETCH_DOC_SIZE_LIMIT,
     )
     .await
@@ -52,5 +59,6 @@ mod tests {
         assert_eq!(args.reference, "skills/x");
         assert_eq!(args.vendor.as_deref(), Some("claude"));
         assert!(args.path.is_none());
+        assert!(args.description.is_none() && args.digest_only.is_none());
     }
 }

--- a/src/mcp/render.rs
+++ b/src/mcp/render.rs
@@ -19,7 +19,7 @@ use anyhow::anyhow;
 use serde::Serialize;
 
 use crate::context::Context;
-use crate::fetch::fetch_artifact;
+use crate::fetch::{FetchedPayload, fetch_artifact};
 use crate::install::client_target::ClientTarget;
 use crate::install::installer::INSTALL_LAYER_SIZE_LIMIT;
 use crate::install::materializer::{ArtifactMaterializer, DefaultMaterializer};
@@ -76,7 +76,17 @@ pub async fn render(ctx: &Context, args: &RenderToolArgs) -> anyhow::Result<Rend
     );
     let access = crate::command::access_seam(ctx)?;
     let fetched = fetch_artifact(&scope, &access, &args.reference, Some(INSTALL_LAYER_SIZE_LIMIT)).await?;
-    match fetched.kind {
+    // A description companion never materializes files; render only ever
+    // fetches a real, installable kind.
+    let kind = match fetched.payload {
+        FetchedPayload::Description => {
+            return Err(anyhow!(
+                "a description companion renders no files; use grim_fetch instead"
+            ));
+        }
+        FetchedPayload::Artifact(kind) => kind,
+    };
+    match kind {
         ArtifactKind::Mcp => {
             return Err(anyhow!(
                 "mcp descriptors register into client configs and render no files; use grim install"
@@ -97,14 +107,9 @@ pub async fn render(ctx: &Context, args: &RenderToolArgs) -> anyhow::Result<Rend
         .tempdir_in(std::env::temp_dir())
         .map_err(|e| anyhow!("cannot create staging dir: {e}"))?;
     let materialized_root = staging.path().join("content");
-    crate::command::grim(DefaultMaterializer.materialize(
-        fetched.kind,
-        &fetched.name,
-        &fetched.blob,
-        &materialized_root,
-    ))?;
+    crate::command::grim(DefaultMaterializer.materialize(kind, &fetched.name, &fetched.blob, &materialized_root))?;
 
-    let canonical = match fetched.kind {
+    let canonical = match kind {
         ArtifactKind::Skill => materialized_root.join(&fetched.name),
         ArtifactKind::Rule | ArtifactKind::Agent => materialized_root.join(format!("{}.md", fetched.name)),
         ArtifactKind::Bundle | ArtifactKind::Mcp => unreachable!("rejected above"),
@@ -113,13 +118,13 @@ pub async fn render(ctx: &Context, args: &RenderToolArgs) -> anyhow::Result<Rend
         return Err(anyhow!(
             "artifact '{}' ({}) did not produce the expected '{}' entry",
             fetched.name,
-            fetched.kind,
+            kind,
             canonical.display()
         ));
     }
 
     // A rule may stage a sibling support directory beside its index.
-    let staged_support: Option<PathBuf> = match fetched.kind {
+    let staged_support: Option<PathBuf> = match kind {
         ArtifactKind::Rule => {
             let dir = materialized_root.join(&fetched.name);
             dir.is_dir().then_some(dir)
@@ -128,7 +133,7 @@ pub async fn render(ctx: &Context, args: &RenderToolArgs) -> anyhow::Result<Rend
     };
 
     std::fs::create_dir_all(&args.dest_dir).map_err(|e| anyhow!("cannot create '{}': {e}", args.dest_dir.display()))?;
-    let dest = match fetched.kind {
+    let dest = match kind {
         ArtifactKind::Skill => args.dest_dir.join(&fetched.name),
         ArtifactKind::Rule | ArtifactKind::Agent => args.dest_dir.join(format!("{}.md", fetched.name)),
         ArtifactKind::Bundle | ArtifactKind::Mcp => unreachable!("rejected above"),
@@ -136,7 +141,7 @@ pub async fn render(ctx: &Context, args: &RenderToolArgs) -> anyhow::Result<Rend
 
     let pinned_str = fetched.pinned.strip_advisory().to_string();
     let written = crate::command::grim(client.materialize(
-        fetched.kind,
+        kind,
         &fetched.name,
         &canonical,
         &dest,
@@ -147,7 +152,7 @@ pub async fn render(ctx: &Context, args: &RenderToolArgs) -> anyhow::Result<Rend
     Ok(RenderReport {
         reference: fetched.identifier.to_string(),
         digest: fetched.pinned.strip_advisory().digest().to_string(),
-        kind: fetched.kind.to_string(),
+        kind: kind.to_string(),
         name: fetched.name,
         vendor: client.as_str().to_string(),
         dest_dir: args.dest_dir.clone(),

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -26,7 +26,7 @@ use crate::cli::exit_code::ExitCode;
 use crate::command::mcp::McpArgs;
 use crate::context::Context;
 use crate::mcp::state::McpState;
-use crate::mcp::tool_args::{FetchToolArgs, RenderToolArgs, SearchToolArgs, StatusToolArgs};
+use crate::mcp::tool_args::{DescribeToolArgs, FetchToolArgs, RenderToolArgs, SearchToolArgs, StatusToolArgs};
 
 /// The MCP server handler. Cloned per request by rmcp (a cheap `Arc` bump
 /// plus the router's shared map).
@@ -110,6 +110,19 @@ impl GrimMcpServer {
         }
     }
 
+    /// Report an artifact's manifest-level metadata (kind, curated
+    /// annotations, tags) into the tool result — no content download, no
+    /// install, no state.
+    #[tool(
+        description = "Describe a Grimoire artifact — its kind, curated metadata (title, description, summary, version, license, repository, keywords, deprecation, replacement), tags, and the verbatim manifest annotation map — without downloading its content. Returns the same JSON as `grim describe --format json`. Requires network access. Scope params (`global`/`config`/`workspace`) only select which registries are consulted."
+    )]
+    async fn grim_describe(&self, Parameters(args): Parameters<DescribeToolArgs>) -> Result<String, ErrorData> {
+        match crate::mcp::describe::describe(&self.inner.ctx, &args).await {
+            Ok(report) => to_json(&report),
+            Err(e) => Err(tool_error("describe", &e)),
+        }
+    }
+
     /// Write an artifact's vendor-native files to a destination directory.
     /// Write tool — registered only when the server was launched with
     /// `--allow-writes` (see [`build_router`]).
@@ -186,7 +199,7 @@ mod tests {
     fn read_tools_always_routed() {
         for allow_writes in [false, true] {
             let router = build_router(allow_writes);
-            for tool in ["grim_search", "grim_status", "grim_fetch"] {
+            for tool in ["grim_search", "grim_status", "grim_fetch", "grim_describe"] {
                 assert!(
                     router.has_route(tool),
                     "{tool} must be routed (allow_writes={allow_writes})"

--- a/src/mcp/tool_args.rs
+++ b/src/mcp/tool_args.rs
@@ -100,6 +100,24 @@ pub struct FetchToolArgs {
     // resolved scope's configured registries are the boundary (CWE-918).
 }
 
+/// Arguments for the `grim_describe` tool.
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct DescribeToolArgs {
+    /// The artifact reference to describe: a short id (`skills/code-review`),
+    /// an alias-qualified ref (`myreg/skills/code-review`), or a fully
+    /// qualified one (`ghcr.io/acme/skills/code-review:1`). Defaults to
+    /// `latest` when no tag/digest is given.
+    #[serde(rename = "ref")]
+    pub reference: String,
+
+    /// Per-call scope selection (registry-set derivation only — describe
+    /// never touches install state).
+    #[serde(flatten, default)]
+    pub scope: ScopeToolArgs,
+    // No `registry` override — same SSRF stance as `SearchToolArgs`: the
+    // resolved scope's configured registries are the boundary (CWE-918).
+}
+
 /// Arguments for the `grim_render` tool (write tool, `--allow-writes`).
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct RenderToolArgs {

--- a/src/mcp/tool_args.rs
+++ b/src/mcp/tool_args.rs
@@ -92,6 +92,18 @@ pub struct FetchToolArgs {
     #[serde(default)]
     pub path: Option<String>,
 
+    /// Fetch the repository description companion (README, logo, CHANGELOG)
+    /// with every member inline, instead of the artifact. No writes — use
+    /// `grim_render` to materialize files.
+    #[serde(default)]
+    pub description: Option<bool>,
+
+    /// Resolve the reference to a digest and return `{ref, digest}` without
+    /// downloading — a cheap cache probe. Composes with `description` to
+    /// probe the companion tag.
+    #[serde(default)]
+    pub digest_only: Option<bool>,
+
     /// Per-call scope selection (registry-set derivation only — fetch
     /// never touches install state).
     #[serde(flatten, default)]
@@ -201,11 +213,36 @@ mod tests {
         for schema in [
             serde_json::to_value(schemars::schema_for!(SearchToolArgs)).unwrap(),
             serde_json::to_value(schemars::schema_for!(StatusToolArgs)).unwrap(),
+            serde_json::to_value(schemars::schema_for!(FetchToolArgs)).unwrap(),
         ] {
             let props = schema.get("properties").expect("schema has properties");
             for key in ["global", "config", "workspace"] {
                 assert!(props.get(key).is_some(), "missing flattened property {key} in {schema}");
             }
+        }
+    }
+
+    #[test]
+    fn fetch_args_expose_description_and_digest_only() {
+        // The new fetch modes deserialize and appear in the published schema.
+        let args: FetchToolArgs =
+            serde_json::from_str(r#"{"ref": "skills/x", "description": true, "digest_only": true}"#).unwrap();
+        assert_eq!(args.description, Some(true));
+        assert_eq!(args.digest_only, Some(true));
+
+        let bare: FetchToolArgs = serde_json::from_str(r#"{"ref": "skills/x"}"#).unwrap();
+        assert!(
+            bare.description.is_none() && bare.digest_only.is_none(),
+            "both default to absent"
+        );
+
+        let schema = serde_json::to_value(schemars::schema_for!(FetchToolArgs)).unwrap();
+        let props = schema.get("properties").expect("schema has properties");
+        for key in ["description", "digest_only"] {
+            assert!(
+                props.get(key).is_some(),
+                "missing fetch-mode property {key} in {schema}"
+            );
         }
     }
 }

--- a/src/oci.rs
+++ b/src/oci.rs
@@ -8,6 +8,7 @@ pub mod access;
 pub mod annotations;
 pub mod artifact_kind;
 pub mod bundle;
+pub mod description;
 pub mod digest;
 pub mod git_provenance;
 pub mod identifier;

--- a/src/oci/annotations.rs
+++ b/src/oci/annotations.rs
@@ -132,6 +132,24 @@ pub fn replacement_ref(annotations: &BTreeMap<String, String>) -> Option<String>
         .and_then(|v| normalize_deprecated(v))
 }
 
+/// Read the keyword list off a manifest's annotation map: the comma-separated
+/// `com.grimoire.keywords` value split on commas, trimmed, with empties
+/// dropped; `[]` when the annotation is absent. The single read seam so the
+/// catalog build, `grim describe`, and the index announce parse keywords
+/// identically (rather than three subtly-diverging inline copies).
+pub fn keywords_from_annotations(annotations: &BTreeMap<String, String>) -> Vec<String> {
+    annotations
+        .get("com.grimoire.keywords")
+        .map(|k| {
+            k.split(',')
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
 /// An authored `repository` metadata value rejected at publish time.
 ///
 /// Raised at publish time (`grim build` / `grim release`) so a bad value

--- a/src/oci/annotations.rs
+++ b/src/oci/annotations.rs
@@ -112,6 +112,26 @@ pub fn deprecation_message(annotations: &BTreeMap<String, String>) -> Option<Str
         .and_then(|v| normalize_deprecated(v))
 }
 
+/// Annotation key carrying a publisher-authored replacement reference.
+///
+/// Optional, authored per kind (skill/agent `metadata.replaced-by`, rule
+/// top-level `replaced-by`, bundle TOML `replaced-by`). The value is a grim
+/// artifact reference naming the successor. Absent or whitespace-only ⇒ no
+/// replacement. Fully independent of [`DEPRECATED_ANNOTATION`]: an artifact
+/// may name a successor without being deprecated (and vice versa). Read back
+/// by the catalog (search) and `grim describe` through [`replacement_ref`].
+pub const REPLACED_BY_ANNOTATION: &str = "com.grimoire.replaced-by";
+
+/// Read the replacement reference off a manifest's annotation map, or `None`
+/// when absent or whitespace-only. Mirrors [`deprecation_message`] — the
+/// single read seam for [`REPLACED_BY_ANNOTATION`], consumed by the catalog
+/// build and `grim describe`. (Shares the trim/empty-⇒-`None` normalization.)
+pub fn replacement_ref(annotations: &BTreeMap<String, String>) -> Option<String> {
+    annotations
+        .get(REPLACED_BY_ANNOTATION)
+        .and_then(|v| normalize_deprecated(v))
+}
+
 /// An authored `repository` metadata value rejected at publish time.
 ///
 /// Raised at publish time (`grim build` / `grim release`) so a bad value
@@ -241,6 +261,9 @@ pub fn annotations_for_skill(
     if let Some(deprecated) = fm.metadata.get("deprecated").and_then(|v| normalize_deprecated(v)) {
         a.insert(DEPRECATED_ANNOTATION.to_string(), deprecated);
     }
+    if let Some(replaced_by) = fm.metadata.get("replaced-by").and_then(|v| normalize_deprecated(v)) {
+        a.insert(REPLACED_BY_ANNOTATION.to_string(), replaced_by);
+    }
     a
 }
 
@@ -289,6 +312,12 @@ pub fn annotations_for_rule(
     {
         a.insert(DEPRECATED_ANNOTATION.to_string(), deprecated);
     }
+    if let Some(replaced_by) = string_from_extra(fm, "replaced-by")
+        .as_deref()
+        .and_then(normalize_deprecated)
+    {
+        a.insert(REPLACED_BY_ANNOTATION.to_string(), replaced_by);
+    }
     a
 }
 
@@ -332,6 +361,9 @@ pub fn annotations_for_agent(
     }
     if let Some(deprecated) = fm.metadata.get("deprecated").and_then(|v| normalize_deprecated(v)) {
         a.insert(DEPRECATED_ANNOTATION.to_string(), deprecated);
+    }
+    if let Some(replaced_by) = fm.metadata.get("replaced-by").and_then(|v| normalize_deprecated(v)) {
+        a.insert(REPLACED_BY_ANNOTATION.to_string(), replaced_by);
     }
     a
 }
@@ -380,6 +412,9 @@ pub fn annotations_for_bundle(
     }
     if let Some(deprecated) = metadata.deprecated.as_deref().and_then(normalize_deprecated) {
         a.insert(DEPRECATED_ANNOTATION.to_string(), deprecated);
+    }
+    if let Some(replaced_by) = metadata.replaced_by.as_deref().and_then(normalize_deprecated) {
+        a.insert(REPLACED_BY_ANNOTATION.to_string(), replaced_by);
     }
     a
 }
@@ -716,6 +751,7 @@ mod tests {
             description: Some("Skills and rules for Python work".to_string()),
             repository: None,
             deprecated: None,
+            replaced_by: None,
         };
         let a = annotations_for_bundle("python-stack", "1.0.0", 3, None, &metadata, None);
         assert_eq!(a["org.opencontainers.image.title"], "python-stack");
@@ -787,6 +823,78 @@ mod tests {
         // Default (no deprecation) omits the key.
         let plain = annotations_for_bundle("python-stack", "1.0.0", 2, None, &BundleMetadata::default(), None);
         assert!(!plain.contains_key(DEPRECATED_ANNOTATION));
+    }
+
+    // ── replaced-by ──────────────────────────────────────────────────
+
+    #[test]
+    fn skill_replaced_by_metadata_becomes_annotation() {
+        let doc = "---\nname: s\ndescription: d\nmetadata:\n  replaced-by: ghcr.io/acme/skills/s2\n---\n";
+        let fm = SkillFrontmatter::parse_doc(doc, Path::new("SKILL.md")).unwrap();
+        let a = annotations_for_skill(&fm, "1.0.0", None, None);
+        assert_eq!(a[REPLACED_BY_ANNOTATION], "ghcr.io/acme/skills/s2");
+        // Independent of deprecation: replaced-by without deprecated emits
+        // only the replacement key.
+        assert!(!a.contains_key(DEPRECATED_ANNOTATION));
+    }
+
+    #[test]
+    fn skill_absent_or_blank_replaced_by_omits_annotation() {
+        let blank = "---\nname: s\ndescription: d\nmetadata:\n  replaced-by: '   '\n---\n";
+        let fm = SkillFrontmatter::parse_doc(blank, Path::new("SKILL.md")).unwrap();
+        assert!(!annotations_for_skill(&fm, "1.0.0", None, None).contains_key(REPLACED_BY_ANNOTATION));
+        let plain = SkillFrontmatter::parse_doc("---\nname: s\ndescription: d\n---\n", Path::new("SKILL.md")).unwrap();
+        assert!(!annotations_for_skill(&plain, "1.0.0", None, None).contains_key(REPLACED_BY_ANNOTATION));
+    }
+
+    #[test]
+    fn rule_replaced_by_from_extra_becomes_annotation() {
+        let doc = "---\npaths: [\"a\"]\nreplaced-by: ghcr.io/acme/rules/r2\n---\n# R\nbody\n";
+        let parsed = RuleFrontmatter::parse_doc(doc, Path::new("r.md")).unwrap();
+        let a = annotations_for_rule("r", &parsed.frontmatter, &parsed.body, "1.0.0", None, None);
+        assert_eq!(a[REPLACED_BY_ANNOTATION], "ghcr.io/acme/rules/r2");
+    }
+
+    #[test]
+    fn agent_replaced_by_metadata_becomes_annotation() {
+        let doc = "---\nname: a\ndescription: d\nmetadata:\n  replaced-by: ghcr.io/acme/agents/a2\n---\nbody\n";
+        let parsed = AgentFrontmatter::parse_doc(doc, Path::new("a.md")).unwrap();
+        let a = annotations_for_agent(&parsed.frontmatter, "1.0.0", None, None);
+        assert_eq!(a[REPLACED_BY_ANNOTATION], "ghcr.io/acme/agents/a2");
+    }
+
+    #[test]
+    fn bundle_replaced_by_metadata_becomes_annotation_independent_of_deprecated() {
+        let metadata = BundleMetadata {
+            replaced_by: Some("ghcr.io/acme/bundles/stack2".to_string()),
+            ..BundleMetadata::default()
+        };
+        let a = annotations_for_bundle("stack", "1.0.0", 2, None, &metadata, None);
+        assert_eq!(a[REPLACED_BY_ANNOTATION], "ghcr.io/acme/bundles/stack2");
+        assert!(
+            !a.contains_key(DEPRECATED_ANNOTATION),
+            "replaced-by does not imply deprecated"
+        );
+        // Default (no replacement) omits the key.
+        let plain = annotations_for_bundle("stack", "1.0.0", 2, None, &BundleMetadata::default(), None);
+        assert!(!plain.contains_key(REPLACED_BY_ANNOTATION));
+    }
+
+    #[test]
+    fn replacement_ref_reads_trims_and_none_on_empty() {
+        let mut ann = BTreeMap::new();
+        assert_eq!(replacement_ref(&ann), None, "absent ⇒ None");
+        ann.insert(
+            REPLACED_BY_ANNOTATION.to_string(),
+            "  ghcr.io/acme/skills/s2  ".to_string(),
+        );
+        assert_eq!(
+            replacement_ref(&ann).as_deref(),
+            Some("ghcr.io/acme/skills/s2"),
+            "trimmed"
+        );
+        ann.insert(REPLACED_BY_ANNOTATION.to_string(), "   ".to_string());
+        assert_eq!(replacement_ref(&ann), None, "whitespace-only ⇒ None");
     }
 
     #[test]

--- a/src/oci/description.rs
+++ b/src/oci/description.rs
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The Grimoire Authors
+
+//! The repository-level **description companion**: a `README.md` (plus
+//! optional assets) published to the reserved `__grimoire` tag in the SAME
+//! repository as an artifact. It gives every kind — skill, rule, agent, mcp,
+//! bundle — one uniform place to carry human-facing docs, retrievable with
+//! `grim fetch <repo>:__grimoire [--path README.md]`.
+//!
+//! The companion is a normal grim tar layer (same media type as an artifact),
+//! so the fetch core's existing unpack / `files[]` / `--path` machinery serves
+//! it unchanged; the only marker is the `com.grimoire.kind: desc` annotation.
+//! It is **not** an [`crate::oci::ArtifactKind`]: `kind_from_manifest` returns
+//! `None` for it, so no artifact surface (install, catalog, `add`) mistakes it
+//! for one. Its reserved `__grimoire` tag keeps it out of every user-facing tag
+//! listing (see [`is_internal_tag`]) while direct resolution still works.
+
+use crate::oci::access::OciAccess;
+use crate::oci::access::error::AccessError;
+use crate::oci::artifact_kind::KIND_ANNOTATION;
+use crate::oci::manifest::{Descriptor, OciManifest};
+use crate::oci::{Algorithm, Digest, Identifier};
+
+/// The reserved tag carrying a repository's description companion.
+///
+/// (`__grimoire`, not `.grimoire`: the OCI tag grammar forbids a leading dot.)
+pub const DESC_TAG: &str = "__grimoire";
+
+/// Prefix for the reserved internal-tag family (`__grimoire.<x>`), held for
+/// future companions. The bare [`DESC_TAG`] (`__grimoire`) is internal too.
+pub const INTERNAL_TAG_PREFIX: &str = "__grimoire.";
+
+/// The `com.grimoire.kind` annotation value marking a description companion.
+/// Deliberately not an [`crate::oci::ArtifactKind`].
+pub const DESC_KIND: &str = "desc";
+
+/// Whether `tag` is a grim-internal tag that must not appear in a user-facing
+/// tag listing — the reserved `__grimoire` tag itself or any `__grimoire.<x>`
+/// companion. Enumeration hides these; direct resolution of `<repo>:__grimoire`
+/// is unaffected (that path resolves the exact tag, it never lists).
+pub fn is_internal_tag(tag: &str) -> bool {
+    tag == DESC_TAG || tag.starts_with(INTERNAL_TAG_PREFIX)
+}
+
+/// Whether `manifest` is a description companion (carries
+/// `com.grimoire.kind: desc`). The fetch core routes these through the
+/// tar-backed content path with `README.md` as the index.
+pub fn is_description_manifest(manifest: &OciManifest) -> bool {
+    manifest.annotations.get(KIND_ANNOTATION).map(String::as_str) == Some(DESC_KIND)
+}
+
+/// Publish the description companion `tar` to `repo`'s reserved [`DESC_TAG`].
+///
+/// Pushes the layer blob, a single-layer manifest marked
+/// `com.grimoire.kind: desc` (the sole discriminator — no custom
+/// `artifactType` / config media type reaches the wire, which GitLab
+/// rejects), then re-points the mutable `__grimoire` tag at it. Deterministic
+/// packing makes an unchanged republish a CAS no-op (identical layer digest ⇒
+/// identical manifest digest ⇒ tag re-point is idempotent). Returns the
+/// pushed manifest digest.
+///
+/// # Errors
+///
+/// [`AccessError`] for a blob/manifest push or tag write failure.
+pub async fn push_description_companion(
+    access: &dyn OciAccess,
+    repo: &Identifier,
+    tar: &[u8],
+) -> Result<Digest, AccessError> {
+    let layer_digest = Algorithm::Sha256.hash(tar);
+    // `desc` is not an [`crate::oci::ArtifactKind`], so `kind_from_manifest`
+    // returns `None` and no artifact surface mistakes the companion for an
+    // installable artifact.
+    let annotations = std::iter::once((KIND_ANNOTATION.to_string(), DESC_KIND.to_string())).collect();
+    let manifest = OciManifest {
+        media_type: Some("application/vnd.oci.image.manifest.v1+json".to_string()),
+        artifact_type: None,
+        config_media_type: None,
+        layers: vec![Descriptor {
+            digest: layer_digest,
+            media_type: "application/vnd.grimoire.artifact.layer.v1.tar".to_string(),
+            size: tar.len() as u64,
+        }],
+        annotations,
+    };
+
+    access.push_blob(repo, tar).await?;
+    let manifest_digest = access.push_manifest(repo, &manifest).await?;
+    // The companion tag is mutable metadata — always (re)point it at the new
+    // manifest. Identical content ⇒ identical digest ⇒ idempotent tag move.
+    access.put_tag(repo, DESC_TAG, &manifest_digest).await?;
+    Ok(manifest_digest)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn internal_tag_covers_reserved_tag_and_family_only() {
+        // The bare reserved tag and the `__grimoire.<x>` family are internal.
+        assert!(is_internal_tag("__grimoire"));
+        assert!(is_internal_tag(DESC_TAG));
+        assert!(is_internal_tag("__grimoire.sbom"));
+        assert!(is_internal_tag("__grimoire.future"));
+        // Everything else — including a near-miss and the old `__grim.` name.
+        assert!(!is_internal_tag("__grimoirefoo"), "no dot, not the exact tag");
+        assert!(!is_internal_tag("__grim.desc"), "the old name is not reserved");
+        assert!(!is_internal_tag("latest"));
+        assert!(!is_internal_tag("1.2.3"));
+    }
+
+    #[test]
+    fn description_manifest_detected_by_kind_annotation() {
+        use crate::oci::manifest::{Descriptor, OciManifest};
+        let mut m = OciManifest {
+            media_type: None,
+            artifact_type: None,
+            config_media_type: None,
+            layers: vec![Descriptor {
+                digest: crate::oci::Algorithm::Sha256.hash(b"x"),
+                media_type: "application/vnd.grimoire.artifact.layer.v1.tar".to_string(),
+                size: 1,
+            }],
+            annotations: std::collections::BTreeMap::new(),
+        };
+        assert!(!is_description_manifest(&m), "no kind annotation ⇒ not a description");
+        m.annotations.insert(KIND_ANNOTATION.to_string(), DESC_KIND.to_string());
+        assert!(is_description_manifest(&m));
+        // A real artifact kind is not a description.
+        m.annotations.insert(KIND_ANNOTATION.to_string(), "skill".to_string());
+        assert!(!is_description_manifest(&m));
+    }
+}

--- a/src/skill.rs
+++ b/src/skill.rs
@@ -34,5 +34,6 @@ pub use skill_frontmatter::SkillFrontmatter;
 pub use skill_name::SkillName;
 #[allow(unused_imports)]
 pub use skill_package::{
-    pack_agent_file, pack_rule_file, pack_skill_dir, validate_agent_file, validate_rule_file, validate_skill_dir,
+    pack_agent_file, pack_description_files, pack_rule_file, pack_skill_dir, validate_agent_file, validate_rule_file,
+    validate_skill_dir,
 };

--- a/src/skill/skill_package.rs
+++ b/src/skill/skill_package.rs
@@ -7,10 +7,12 @@
 //!
 //! The pack ↔ install round-trip is a hard contract: `pack_skill_dir`
 //! emits entries rooted at `<name>/`, while `pack_rule_file` and
-//! `pack_agent_file` emit a single `<name>.md` (the rule variant plus an
-//! optional support dir), byte-for-byte what the materializer (and the
-//! acceptance harness `make_artifact`) extracts. The tar entries are
-//! emitted in sorted path order so the layer digest is deterministic.
+//! `pack_agent_file` emit a `<name>.md` index — the rule variant plus an
+//! optional support dir, the agent variant plus any well-known companion
+//! files (`README.md`, `logo.png`, `logo.svg`) — byte-for-byte what the
+//! materializer (and the acceptance harness `make_artifact`) extracts. The
+//! tar entries are emitted in sorted path order so the layer digest is
+//! deterministic.
 
 use std::path::{Path, PathBuf};
 
@@ -275,13 +277,25 @@ pub fn pack_rule_file(file: &Path) -> Result<Vec<u8>, SkillError> {
         .map_err(|e| SkillError::new(file, SkillErrorKind::Io(e)))
 }
 
-/// Pack the agent file at `file` into an uncompressed tar with exactly one
-/// `<name>.md` entry.
+/// Well-known companion files an agent may ship in a sibling directory that
+/// shares its stem (`agents/<name>/`): a human-facing `README.md` and a
+/// `logo.png` / `logo.svg` for a catalog/gallery UI. They ride the layer as
+/// `<name>/<file>` — retrievable with `grim fetch <ref> --path <name>/README.md`,
+/// the same path shape a skill or a rule uses. This is a fixed allowlist, not
+/// a general support dir: any other file in the sibling directory is ignored,
+/// so an agent's identity stays the standalone `<name>.md`.
+const AGENT_COMPANIONS: &[&str] = &["README.md", "logo.png", "logo.svg"];
+
+/// Pack the agent file at `file` into an uncompressed tar: the `<name>.md`
+/// index plus any [well-known companion][AGENT_COMPANIONS] found in a sibling
+/// directory sharing the stem (`agents/<name>/README.md`, `…/logo.png`, …),
+/// each emitted as `<name>/<file>`.
 ///
-/// Unlike [`pack_rule_file`], a sibling directory sharing the stem is
-/// **not** packed — agents have no support-directory contract (every
-/// client reads a standalone agent file). The single stable-header entry
-/// makes the layer digest deterministic.
+/// Unlike [`pack_rule_file`], the sibling directory contributes ONLY those
+/// allowlisted files — never an arbitrary tree — so a client still reads a
+/// standalone agent file. Entries are emitted in sorted path order for a
+/// deterministic digest; an agent with no companions packs byte-identically
+/// to the single `<name>.md` entry it always did.
 ///
 /// # Errors
 ///
@@ -289,13 +303,41 @@ pub fn pack_rule_file(file: &Path) -> Result<Vec<u8>, SkillError> {
 /// [`SkillErrorKind::NameInvalid`] for a stem-less path.
 pub fn pack_agent_file(file: &Path) -> Result<Vec<u8>, SkillError> {
     let name = rule_name(file)?;
-    // Bound the single-file read before pulling it into memory (CWE-400/770).
-    let meta = std::fs::metadata(file).map_err(|e| SkillError::new(file, SkillErrorKind::Io(e)))?;
-    check_pack_bounds(file, meta.len(), 1, &PackLimits::DEFAULT)?;
-    let bytes = read_capped(file, PackLimits::DEFAULT.byte_limit)?;
+
+    let limits = &PackLimits::DEFAULT;
+
+    let mut files: Vec<(String, PathBuf)> = vec![(format!("{name}.md"), file.to_path_buf())];
+
+    // The companion dir shares the index's stem: for `agents/<name>.md` it is
+    // `agents/<name>/` (same discovery as a rule's support dir). Only the
+    // allowlisted files ride; everything else there is deliberately ignored.
+    let companion_dir = file.with_extension("");
+    if companion_dir.is_dir() {
+        for well_known in AGENT_COMPANIONS {
+            let candidate = companion_dir.join(well_known);
+            if candidate.is_file() {
+                files.push((format!("{name}/{well_known}"), candidate));
+            }
+        }
+    }
+    files.sort_by(|a, b| a.0.cmp(&b.0));
+
+    // Bound the cumulative size before reading any file into memory
+    // (CWE-400/770); the read-side cap below is the TOCTOU backstop.
+    let mut total_bytes: u64 = 0;
+    for (_, abs) in &files {
+        let meta = std::fs::metadata(abs).map_err(|e| SkillError::new(abs, SkillErrorKind::Io(e)))?;
+        total_bytes = total_bytes.saturating_add(meta.len());
+    }
+    check_pack_bounds(file, total_bytes, files.len(), limits)?;
+
     let mut builder = tar::Builder::new(Vec::new());
-    append_entry(&mut builder, &format!("{name}.md"), &bytes)
-        .map_err(|e| SkillError::new(file, SkillErrorKind::Io(e)))?;
+    let mut read_bytes: u64 = 0;
+    for (entry_path, abs) in &files {
+        let bytes = read_capped(abs, limits.byte_limit.saturating_sub(read_bytes))?;
+        read_bytes = read_bytes.saturating_add(bytes.len() as u64);
+        append_entry(&mut builder, entry_path, &bytes).map_err(|e| SkillError::new(abs, SkillErrorKind::Io(e)))?;
+    }
     builder
         .into_inner()
         .map_err(|e| SkillError::new(file, SkillErrorKind::Io(e)))
@@ -761,9 +803,11 @@ mod tests {
     }
 
     #[test]
-    fn pack_agent_ignores_sibling_dir_and_is_deterministic() {
-        // Agents have no support-directory contract: a sibling dir sharing
-        // the stem must NOT be packed (unlike rules).
+    fn pack_agent_ignores_non_wellknown_sibling_and_is_deterministic() {
+        // The sibling dir contributes ONLY the well-known companions: an
+        // arbitrary file there (`extra.md`) must NOT ride, so the agent stays
+        // a standalone `<name>.md`. A no-companion agent is byte-identical to
+        // the historical single-entry pack.
         let tmp = tempfile::tempdir().unwrap();
         let f = tmp.path().join("my-agent.md");
         write(&f, "---\nname: my-agent\ndescription: d\n---\nbody\n");
@@ -778,6 +822,70 @@ mod tests {
             .materialize(ArtifactKind::Agent, "my-agent", &first, &dest)
             .expect("materialize");
         assert_eq!(written, vec![PathBuf::from("my-agent.md")], "single entry only");
+    }
+
+    #[test]
+    fn pack_agent_with_readme_and_logo_round_trips() {
+        // A README + logo in the sibling companion dir ride the layer as
+        // `<name>/README.md` / `<name>/logo.png`, retrievable via the same
+        // `--path <name>/README.md` shape a skill/rule uses.
+        let tmp = tempfile::tempdir().unwrap();
+        let f = tmp.path().join("agents/code-reviewer.md");
+        let doc = "---\nname: code-reviewer\ndescription: d\n---\nYou review code.\n";
+        write(&f, doc);
+        write(&tmp.path().join("agents/code-reviewer/README.md"), "# Code Reviewer\n");
+        // A non-UTF-8 logo proves binary companions ride verbatim.
+        std::fs::write(
+            tmp.path().join("agents/code-reviewer/logo.png"),
+            [0x89u8, 0x50, 0x4e, 0x47, 0x00, 0xff],
+        )
+        .unwrap();
+        // A stray file in the companion dir is ignored (allowlist only).
+        write(&tmp.path().join("agents/code-reviewer/notes.txt"), "ignored\n");
+
+        let tar = pack_agent_file(&f).expect("pack");
+        let dest = tmp.path().join("out");
+        let written = DefaultMaterializer
+            .materialize(ArtifactKind::Agent, "code-reviewer", &tar, &dest)
+            .expect("materialize");
+        // The materializer returns `written` sorted as `PathBuf`
+        // (component-wise), so the companion files precede the index file.
+        assert_eq!(
+            written,
+            vec![
+                PathBuf::from("code-reviewer/README.md"),
+                PathBuf::from("code-reviewer/logo.png"),
+                PathBuf::from("code-reviewer.md"),
+            ],
+            "index + well-known companions only; notes.txt excluded"
+        );
+        assert_eq!(std::fs::read_to_string(dest.join("code-reviewer.md")).unwrap(), doc);
+        assert_eq!(
+            std::fs::read_to_string(dest.join("code-reviewer/README.md")).unwrap(),
+            "# Code Reviewer\n"
+        );
+        assert_eq!(
+            std::fs::read(dest.join("code-reviewer/logo.png")).unwrap(),
+            [0x89u8, 0x50, 0x4e, 0x47, 0x00, 0xff]
+        );
+
+        // Deterministic across repeated packs.
+        assert_eq!(tar, pack_agent_file(&f).unwrap(), "companion pack must be byte-stable");
+    }
+
+    #[test]
+    fn pack_agent_without_companion_dir_is_single_entry() {
+        // The degenerate case (no sibling dir at all) is exactly one entry,
+        // byte-identical to the historical single-file agent pack.
+        let tmp = tempfile::tempdir().unwrap();
+        let f = tmp.path().join("solo.md");
+        write(&f, "---\nname: solo\ndescription: d\n---\nbody\n");
+        let tar = pack_agent_file(&f).expect("pack");
+        let dest = tmp.path().join("out");
+        let written = DefaultMaterializer
+            .materialize(ArtifactKind::Agent, "solo", &tar, &dest)
+            .expect("materialize");
+        assert_eq!(written, vec![PathBuf::from("solo.md")]);
     }
 
     #[test]

--- a/src/skill/skill_package.rs
+++ b/src/skill/skill_package.rs
@@ -376,6 +376,61 @@ fn read_capped(path: &Path, remaining: u64) -> Result<Vec<u8>, SkillError> {
     Ok(bytes)
 }
 
+/// Pack an explicit `(packed_name, source_path)` mapping into the
+/// uncompressed tar layer for the reserved `__grimoire` description
+/// companion. Each source file is read and appended under its packed name —
+/// well-known files (`README.md`, `logo.png`|`logo.svg`, `CHANGELOG.md`) map
+/// their source path onto the wire name; `include` glob hits keep their
+/// relative path. Entries are emitted in sorted packed-name order with stable
+/// headers (no mtime/uid/gid), so republishing byte-identical content produces
+/// an identical layer digest — the CAS no-op the caller relies on.
+///
+/// The mapping must be **non-empty**: an empty companion carries nothing, so
+/// the caller resolves that to a data error (there is no README-required gate
+/// anymore — every member is optional as long as at least one is present).
+///
+/// # Errors
+///
+/// [`SkillErrorKind::ValidationFailed`] when the mapping is empty;
+/// [`SkillErrorKind::Io`] for a read failure;
+/// [`SkillErrorKind::TooLarge`] when the files exceed the packing bounds.
+pub fn pack_description_files(files: &[(String, PathBuf)]) -> Result<Vec<u8>, SkillError> {
+    let limits = &PackLimits::DEFAULT;
+
+    let Some((_, first)) = files.first() else {
+        return Err(SkillError::new(
+            Path::new("description"),
+            SkillErrorKind::ValidationFailed("description companion resolves to no files".to_string()),
+        ));
+    };
+    let root = first.clone();
+
+    // Deterministic order: sort by the on-wire packed name.
+    let mut files: Vec<(String, PathBuf)> = files.to_vec();
+    files.sort_by(|a, b| a.0.cmp(&b.0));
+
+    // Bound the cumulative size (from metadata) and file count before reading
+    // any file into memory (CWE-400/770); the read-side cap below is the
+    // TOCTOU backstop.
+    let mut total_bytes: u64 = 0;
+    for (_, abs) in &files {
+        let meta = std::fs::metadata(abs).map_err(|e| SkillError::new(abs, SkillErrorKind::Io(e)))?;
+        total_bytes = total_bytes.saturating_add(meta.len());
+    }
+    check_pack_bounds(&root, total_bytes, files.len(), limits)?;
+
+    let mut builder = tar::Builder::new(Vec::new());
+    let mut read_bytes: u64 = 0;
+    for (entry_path, abs) in &files {
+        let bytes = read_capped(abs, limits.byte_limit.saturating_sub(read_bytes))?;
+        read_bytes = read_bytes.saturating_add(bytes.len() as u64);
+        append_entry(&mut builder, entry_path, &bytes).map_err(|e| SkillError::new(abs, SkillErrorKind::Io(e)))?;
+    }
+    builder
+        .into_inner()
+        .map_err(|e| SkillError::new(&root, SkillErrorKind::Io(e)))
+}
+
 /// Append one regular-file entry with a stable header (mode 0o644, no
 /// mtime/uid/gid noise) so the produced tar bytes are deterministic.
 fn append_entry(builder: &mut tar::Builder<Vec<u8>>, path: &str, bytes: &[u8]) -> std::io::Result<()> {
@@ -557,6 +612,8 @@ fn collect_files(
                     _ => None,
                 })
                 .collect();
+            // Root the entry at `<root_name>/<rel>` (skill / rule / agent —
+            // every caller passes a non-empty name).
             let entry = format!("{root_name}/{}", rel_str.join("/"));
             state.out.push((entry, path));
             state.total_bytes = state.total_bytes.saturating_add(meta.len());
@@ -886,6 +943,71 @@ mod tests {
             .materialize(ArtifactKind::Agent, "solo", &tar, &dest)
             .expect("materialize");
         assert_eq!(written, vec![PathBuf::from("solo.md")]);
+    }
+
+    #[test]
+    fn pack_description_files_maps_source_paths_onto_wire_names_and_round_trips() {
+        // The mapping decouples repo layout from wire layout: `assets/brand.png`
+        // packs as the well-known `logo.png`, `docs/CHANGES.md` as `CHANGELOG.md`.
+        let tmp = tempfile::tempdir().unwrap();
+        let src = tmp.path().join("src");
+        write(&src.join("README.md"), "# Repo\n\nWhat this repo ships.\n");
+        write(&src.join("docs/CHANGES.md"), "# Changelog\n");
+        write(&src.join("docs/img/diagram.svg"), "<svg/>\n");
+        std::fs::create_dir_all(src.join("assets")).unwrap();
+        std::fs::write(src.join("assets/brand.png"), [0x89u8, 0x50, 0x4e, 0x47, 0x00, 0xff]).unwrap();
+
+        let files = vec![
+            ("README.md".to_string(), src.join("README.md")),
+            ("CHANGELOG.md".to_string(), src.join("docs/CHANGES.md")),
+            ("logo.png".to_string(), src.join("assets/brand.png")),
+            // An `include` glob hit keeps its relative path.
+            ("docs/img/diagram.svg".to_string(), src.join("docs/img/diagram.svg")),
+        ];
+        let tar = pack_description_files(&files).expect("pack");
+        let dest = tmp.path().join("out");
+        // The materializer is generic over the tar; Skill kind is just a label.
+        let written = DefaultMaterializer
+            .materialize(ArtifactKind::Skill, "description", &tar, &dest)
+            .expect("materialize");
+        assert_eq!(
+            written,
+            vec![
+                PathBuf::from("CHANGELOG.md"),
+                PathBuf::from("README.md"),
+                PathBuf::from("docs/img/diagram.svg"),
+                PathBuf::from("logo.png"),
+            ],
+            "packed under wire names, sorted by packed name"
+        );
+        assert_eq!(
+            std::fs::read_to_string(dest.join("README.md")).unwrap(),
+            "# Repo\n\nWhat this repo ships.\n"
+        );
+        assert_eq!(
+            std::fs::read(dest.join("logo.png")).unwrap(),
+            [0x89u8, 0x50, 0x4e, 0x47, 0x00, 0xff]
+        );
+
+        // CAS: byte-identical content re-packs to identical bytes (same digest).
+        assert_eq!(
+            tar,
+            pack_description_files(&files).unwrap(),
+            "republish must be byte-stable"
+        );
+    }
+
+    #[test]
+    fn pack_description_files_readme_optional_but_not_empty() {
+        // No README-required gate: a logo-only companion packs fine.
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("logo.png"), [0x89u8, 0x50, 0x4e, 0x47]).unwrap();
+        let files = vec![("logo.png".to_string(), tmp.path().join("logo.png"))];
+        assert!(pack_description_files(&files).is_ok(), "README is optional");
+
+        // But an empty mapping is a data error (nothing to publish).
+        let err = pack_description_files(&[]).expect_err("empty companion is rejected");
+        assert!(matches!(err.kind, SkillErrorKind::ValidationFailed(_)));
     }
 
     #[test]

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -3133,6 +3133,7 @@ mod tests {
                 revision: None,
                 created: None,
                 deprecated: None,
+                replaced_by: None,
                 oci: crate::catalog::OciMeta::default(),
                 latest_tag: Some("1.2.3".to_string()),
                 version: Some("1.2.3".to_string()),

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1812,6 +1812,10 @@ fn order_tags(tags: Vec<String>) -> Vec<String> {
     let mut semver: Vec<(semver::Version, String)> = Vec::new();
     let mut other = Vec::new();
     for t in tags {
+        // Internal companions (`__grimoire`, …) never show in the picker.
+        if crate::oci::description::is_internal_tag(&t) {
+            continue;
+        }
         if t == "latest" {
             latest.push(t);
         } else if let Ok(v) = semver::Version::parse(&t.replace('_', "+")) {

--- a/test/src/helpers.py
+++ b/test/src/helpers.py
@@ -87,6 +87,22 @@ def make_bundle(
     return push_artifact(repo, tag, layer, "bundle")
 
 
+def make_description(repo: str, files: dict[str, str | bytes]) -> PublishedArtifact:
+    """Build and push a repository description companion at the reserved
+    ``__grimoire`` tag.
+
+    Mirrors :func:`make_artifact` but tags the reserved companion tag and
+    marks the manifest ``com.grimoire.kind: desc`` (the sole discriminator —
+    ``kind_from_manifest`` returns ``None`` for it, so the read path routes it
+    to the description path, not an installable kind). ``files`` is the
+    companion tree (``README.md``, ``logo.png``, ``CHANGELOG.md``, …). Pushes
+    directly to the registry so the fetch read lane does not depend on
+    ``grim publish``.
+    """
+    tar_bytes = _tar_of(files)
+    return push_artifact(repo, "__grimoire", tar_bytes, "desc")
+
+
 def make_artifact(
     repo: str,
     kind: str,

--- a/test/tests/test_agents.py
+++ b/test/tests/test_agents.py
@@ -160,6 +160,41 @@ def test_release_with_kind_agent_publishes_agent_kind(
     )
 
 
+def test_release_agent_packs_wellknown_readme_companion(
+    grim_at, project_dir: Path, registry: str, unique_repo: str
+) -> None:
+    """``grim release --kind agent`` packs a `README.md` from the sibling
+    companion directory (`agents/<name>/`) into the layer tree, so it round-trips
+    through `grim fetch --path <name>/README.md` — the same path shape a skill
+    or rule uses. A stray file in that directory is NOT packed (allowlist only)."""
+    agent_file = project_dir / "agents" / "my-agent.md"
+    _write(agent_file, _agent_doc("my-agent"))
+    readme = "# my-agent\n\nWhat this agent does and how to use it.\n"
+    _write(project_dir / "agents" / "my-agent" / "README.md", readme)
+    # A non-well-known sibling file must stay out of the layer.
+    _write(project_dir / "agents" / "my-agent" / "notes.txt", "scratch\n")
+
+    repo_path = f"{unique_repo}/my-agent"
+    repo = f"{registry}/{repo_path}"
+    runner = grim_at(project_dir)
+
+    out = runner.json("release", "--kind", "agent", str(agent_file), f"{repo}:1.0.0")
+    assert out["pushed"] is True
+
+    # files[] lists the index and the README companion, not the stray file.
+    doc = runner.json("fetch", f"{repo}:1.0.0")
+    assert doc["kind"] == "agent"
+    paths = [f["path"] for f in doc["files"]]
+    assert "my-agent.md" in paths
+    assert "my-agent/README.md" in paths
+    assert "my-agent/notes.txt" not in paths, "only well-known companions ride the layer"
+
+    # The README pulls back byte-identical via the uniform `<name>/README.md` path.
+    result = runner.plain("fetch", f"{repo}:1.0.0", "--path", "my-agent/README.md")
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == readme
+
+
 # ---------------------------------------------------------------------------
 # b. bare agent-shaped .md WITHOUT --kind → rule + stderr warning
 # ---------------------------------------------------------------------------

--- a/test/tests/test_context.py
+++ b/test/tests/test_context.py
@@ -41,7 +41,37 @@ def test_context_reports_scope_paths_clients_registries(
         r["alias"] == "test" and r["url"] == registry and r["default"] and r["kind"] == "registry"
         for r in regs
     ), regs
+    # `authenticated` is always present as a bool; the isolated HOME has no
+    # docker config, so nothing is authenticated.
+    for r in regs:
+        assert isinstance(r["authenticated"], bool)
+        assert r["authenticated"] is False, r
     assert doc["default_registry"] == registry
+
+
+def test_context_registry_authenticated_from_docker_config(
+    grim_at, project_dir: Path, tmp_path: Path
+) -> None:
+    """A stored credential for the registry's host flips `authenticated`.
+
+    Offline and hermetic: `grim context` never dials the registry, and the
+    credential presence is derived from a temp `$DOCKER_CONFIG` file — no
+    real keychain or network involved.
+    """
+    _project(project_dir, "private.example.com/team")
+    docker_dir = tmp_path / "docker"
+    docker_dir.mkdir()
+    # An `auths` entry for the host (namespace path stripped by the probe).
+    (docker_dir / "config.json").write_text(
+        '{"auths": {"private.example.com": {"auth": "dXNlcjpwYXNz"}}}'
+    )
+
+    runner = grim_at(project_dir)
+    runner.env["DOCKER_CONFIG"] = str(docker_dir)
+    doc = runner.json("context")
+
+    reg = next(r for r in doc["registries"] if r["url"] == "private.example.com/team")
+    assert reg["authenticated"] is True, doc["registries"]
 
 
 def test_context_global_scope(grim_at, project_dir: Path, grim_home: Path) -> None:

--- a/test/tests/test_desc.py
+++ b/test/tests/test_desc.py
@@ -1,0 +1,257 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 The Grimoire Authors
+"""Repository description companion acceptance tests (publish.toml-driven).
+
+A description companion (README + optional logo/changelog/assets) rides the
+`grim publish` batch: after each entry's artifact is pushed, its repository's
+reserved ``__grimoire`` tag is (re)pointed at a tar of the repo's descriptive
+files. The companion is read back through the normal `grim fetch` path — uniform
+for every artifact kind — and the internal tag never leaks into user-facing tag
+listings.
+
+The companion source is resolved per entry: an explicit ``[description]`` table
+(top-level fan-out or a per-entry override) wins over a conventional probe of the
+manifest directory; ``description = false`` opts an entry out; ``publish = false``
+is the manifest-wide kill switch.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+README = "# Repo\n\nWhat this repository ships and how to use it.\n"
+CHANGELOG = "# Changelog\n\n## 1.0.0\n\n- first release\n"
+# A minimal non-UTF-8 asset (PNG signature + a 0xFF byte) rides the layer too.
+LOGO = bytes([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0xFF])
+
+
+def _write(p: Path, body: str) -> None:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(body)
+
+
+def _skill(project_dir: Path, name: str) -> None:
+    """Write a minimal valid skill source under skills/<name>/."""
+    _write(
+        project_dir / "skills" / name / "SKILL.md",
+        f"---\nname: {name}\ndescription: A test skill for the desc suite.\n---\n# {name}\n",
+    )
+
+
+def _manifest(project_dir: Path, registry: str, body: str) -> None:
+    """Write a publish.toml whose top line is the required `registry` field."""
+    (project_dir / "publish.toml").write_text(f'registry = "{registry}"\n{body}')
+
+
+def test_conventional_probe_round_trip(
+    grim_at, project_dir: Path, registry: str, unique_repo: str
+) -> None:
+    """With no [description] table, grim probes the manifest directory for
+    conventional files and auto-publishes a companion, read back via fetch."""
+    prefix = unique_repo.split("/")[-1]
+    name = f"{prefix}-probe"
+    _skill(project_dir, name)
+    # Conventional files at the manifest root — probed automatically.
+    _write(project_dir / "README.md", README)
+    _write(project_dir / "CHANGELOG.md", CHANGELOG)
+    (project_dir / "logo.png").write_bytes(LOGO)
+    _manifest(project_dir, registry, f'\n[skills.{name}]\nversion = "0.1.0"\n')
+
+    runner = grim_at(project_dir)
+    out = runner.json("publish")
+    descs = out["descriptions"]["items"]
+    assert len(descs) == 1, f"one companion expected, got {descs}"
+    assert descs[0]["ref"].endswith(":__grimoire")
+    assert descs[0]["repository"] == f"{registry}/skills/{name}"
+    assert descs[0]["digest"].startswith("sha256:")
+    assert set(descs[0]["files"]) == {"README.md", "CHANGELOG.md", "logo.png"}
+
+    repo = f"{registry}/skills/{name}"
+    doc = runner.json("fetch", f"{repo}:__grimoire")
+    assert doc["kind"] == "desc"
+    paths = [f["path"] for f in doc["files"]]
+    assert {"README.md", "CHANGELOG.md", "logo.png"} <= set(paths)
+    assert doc["content"] == README  # README.md is the default index
+
+    changelog = runner.plain("fetch", f"{repo}:__grimoire", "--path", "CHANGELOG.md")
+    assert changelog.returncode == 0, changelog.stderr
+    assert changelog.stdout == CHANGELOG
+
+
+def test_explicit_mapping_source_name_differs_from_packed_name(
+    grim_at, project_dir: Path, registry: str, unique_repo: str
+) -> None:
+    """An explicit [description] maps arbitrary source paths onto the well-known
+    wire names: docs/readme.md → README.md, brand/icon.svg → logo.svg."""
+    prefix = unique_repo.split("/")[-1]
+    name = f"{prefix}-explicit"
+    _skill(project_dir, name)
+    _write(project_dir / "docs" / "readme.md", README)
+    _write(project_dir / "brand" / "icon.svg", "<svg/>\n")
+    _manifest(
+        project_dir,
+        registry,
+        "\n[description]\n"
+        'readme = "docs/readme.md"\n'
+        'logo = "brand/icon.svg"\n'
+        f'\n[skills.{name}]\nversion = "0.1.0"\n',
+    )
+
+    runner = grim_at(project_dir)
+    out = runner.json("publish")
+    files = out["descriptions"]["items"][0]["files"]
+    assert set(files) == {"README.md", "logo.svg"}, f"source names map to wire names, got {files}"
+
+    doc = runner.json("fetch", f"{registry}/skills/{name}:__grimoire")
+    assert doc["content"] == README
+    logo = runner.plain("fetch", f"{registry}/skills/{name}:__grimoire", "--path", "logo.svg")
+    assert logo.returncode == 0, logo.stderr
+    assert logo.stdout == "<svg/>\n"
+
+
+def test_per_entry_override_and_false_optout(
+    grim_at, project_dir: Path, registry: str, unique_repo: str
+) -> None:
+    """A per-entry [<kind>.<name>.description] overrides the top-level fan-out;
+    `description = false` opts an entry out entirely."""
+    prefix = unique_repo.split("/")[-1]
+    a, b = f"{prefix}-a", f"{prefix}-b"
+    _skill(project_dir, a)
+    _skill(project_dir, b)
+    _write(project_dir / "README.md", README)  # top-level fan-out source
+    _write(project_dir / "skills" / a / "OWN.md", "# entry-specific readme\n")
+    _manifest(
+        project_dir,
+        registry,
+        "\n[description]\n"
+        'readme = "README.md"\n'
+        f"\n[skills.{a}]\nversion = \"0.1.0\"\n"
+        f'[skills.{a}.description]\nreadme = "skills/{a}/OWN.md"\n'
+        f"\n[skills.{b}]\nversion = \"0.1.0\"\ndescription = false\n",
+    )
+
+    runner = grim_at(project_dir)
+    out = runner.json("publish")
+    repos = {d["repository"] for d in out["descriptions"]["items"]}
+    assert repos == {f"{registry}/skills/{a}"}, f"only {a} gets a companion, got {repos}"
+
+    # a's companion carries the per-entry override, not the top-level README.
+    doc_a = runner.json("fetch", f"{registry}/skills/{a}:__grimoire")
+    assert doc_a["content"] == "# entry-specific readme\n"
+
+    # b opted out: no companion published, fetch is a clean not-found.
+    miss = runner.plain("fetch", f"{registry}/skills/{b}:__grimoire", check=False)
+    assert miss.returncode != 0
+    assert "not found" in miss.stderr.lower()
+
+
+def test_fanout_same_companion_on_every_repo(
+    grim_at, project_dir: Path, registry: str, unique_repo: str
+) -> None:
+    """A top-level [description] fans out to every entry's repository with
+    byte-identical content ⇒ identical manifest digest on each repo."""
+    prefix = unique_repo.split("/")[-1]
+    a, b = f"{prefix}-fa", f"{prefix}-fb"
+    _skill(project_dir, a)
+    _skill(project_dir, b)
+    _write(project_dir / "README.md", README)
+    _manifest(
+        project_dir,
+        registry,
+        "\n[description]\n"
+        'readme = "README.md"\n'
+        f"\n[skills.{a}]\nversion = \"0.1.0\"\n"
+        f"\n[skills.{b}]\nversion = \"0.1.0\"\n",
+    )
+
+    runner = grim_at(project_dir)
+    out = runner.json("publish")
+    descs = {d["repository"]: d for d in out["descriptions"]["items"]}
+    assert set(descs) == {f"{registry}/skills/{a}", f"{registry}/skills/{b}"}
+    digests = {d["digest"] for d in descs.values()}
+    assert len(digests) == 1, f"identical companion content ⇒ one digest, got {digests}"
+
+    for repo in (a, b):
+        doc = runner.json("fetch", f"{registry}/skills/{repo}:__grimoire")
+        assert doc["content"] == README
+
+
+def test_republish_unchanged_is_identical_digest(
+    grim_at, project_dir: Path, registry: str, unique_repo: str
+) -> None:
+    """Deterministic packing ⇒ an unchanged republish is a CAS no-op: identical
+    companion manifest digest across runs."""
+    prefix = unique_repo.split("/")[-1]
+    name = f"{prefix}-cas"
+    _skill(project_dir, name)
+    _write(project_dir / "README.md", README)
+    _manifest(project_dir, registry, f'\n[skills.{name}]\nversion = "0.1.0"\n')
+
+    runner = grim_at(project_dir)
+    first = runner.json("publish")["descriptions"]["items"][0]["digest"]
+    second = runner.json("publish")["descriptions"]["items"][0]["digest"]
+    assert first == second, "unchanged republish must yield the same companion digest"
+
+
+def test_dry_run_previews_companion_and_pushes_nothing(
+    grim_at, project_dir: Path, registry: str, unique_repo: str
+) -> None:
+    """--dry-run lists the planned companion (digest null) but pushes nothing:
+    the reserved tag stays absent on the registry."""
+    prefix = unique_repo.split("/")[-1]
+    name = f"{prefix}-dry"
+    _skill(project_dir, name)
+    _write(project_dir / "README.md", README)
+    _manifest(project_dir, registry, f'\n[skills.{name}]\nversion = "0.1.0"\n')
+
+    runner = grim_at(project_dir)
+    out = runner.json("publish", "--dry-run")
+    descs = out["descriptions"]["items"]
+    assert len(descs) == 1
+    assert descs[0]["repository"] == f"{registry}/skills/{name}"
+    assert descs[0]["digest"] is None, "dry-run pushes nothing, so no digest"
+    assert set(descs[0]["files"]) == {"README.md"}
+
+    # Nothing was pushed — the companion tag must not resolve.
+    miss = runner.plain("fetch", f"{registry}/skills/{name}:__grimoire", check=False)
+    assert miss.returncode != 0
+    assert "not found" in miss.stderr.lower()
+
+
+def test_empty_resolution_publishes_no_companion(
+    grim_at, project_dir: Path, registry: str, unique_repo: str
+) -> None:
+    """No [description] table and no conventional files ⇒ no companion, and the
+    publish still succeeds (an absent companion is not an error)."""
+    prefix = unique_repo.split("/")[-1]
+    name = f"{prefix}-empty"
+    _skill(project_dir, name)
+    _manifest(project_dir, registry, f'\n[skills.{name}]\nversion = "0.1.0"\n')
+
+    runner = grim_at(project_dir)
+    result = runner.run("publish", format="json", check=False)
+    assert result.returncode == 0, result.stderr
+    import json
+
+    assert json.loads(result.stdout)["descriptions"]["items"] == [], "no companion resolved"
+
+    miss = runner.plain("fetch", f"{registry}/skills/{name}:__grimoire", check=False)
+    assert miss.returncode != 0
+    assert "not found" in miss.stderr.lower()
+
+
+def test_companion_tag_hidden_from_describe_tags(
+    grim_at, project_dir: Path, registry: str, unique_repo: str
+) -> None:
+    """The `__grimoire` companion tag must not leak into describe `tags[]`."""
+    prefix = unique_repo.split("/")[-1]
+    name = f"{prefix}-hidden"
+    _skill(project_dir, name)
+    _write(project_dir / "README.md", README)
+    _manifest(project_dir, registry, f'\n[skills.{name}]\nversion = "1.0.0"\n')
+
+    runner = grim_at(project_dir)
+    runner.json("publish")
+
+    d = runner.json("describe", f"{registry}/skills/{name}:1.0.0")
+    assert "__grimoire" not in d["tags"], f"internal tag leaked into describe tags[]: {d['tags']}"
+    assert "1.0.0" in d["tags"]

--- a/test/tests/test_describe.py
+++ b/test/tests/test_describe.py
@@ -1,0 +1,159 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 The Grimoire Authors
+"""`grim describe` acceptance tests — manifest-level metadata, no blob pull."""
+from __future__ import annotations
+
+import json
+import uuid
+from pathlib import Path
+
+from src.helpers import make_artifact
+
+
+SKILL_DOC = (
+    "---\n"
+    "name: describe-demo\n"
+    "description: Demo skill for describe tests.\n"
+    "---\n"
+    "# Describe Demo\n"
+)
+
+FULL_ANNOTATIONS = {
+    "org.opencontainers.image.title": "describe-demo",
+    "org.opencontainers.image.description": "Demo skill for describe tests.",
+    "com.grimoire.summary": "terse blurb",
+    "org.opencontainers.image.version": "1.2.0",
+    "org.opencontainers.image.licenses": "Apache-2.0",
+    "org.opencontainers.image.source": "https://github.com/acme/describe-demo",
+    "com.grimoire.keywords": "review, quality",
+    "com.grimoire.deprecated": "use acme/describe-demo-2",
+    "com.grimoire.replaced-by": "ghcr.io/acme/skills/describe-demo-2",
+}
+
+
+def _publish(registry: str, unique_repo: str, *, tags=("latest",), annotations=None) -> str:
+    """Publish a describe-demo skill under one or more tags; return its ref."""
+    repo = f"{unique_repo}/skills/describe-demo"
+    for tag in tags:
+        make_artifact(
+            repo,
+            "skill",
+            {"describe-demo/SKILL.md": SKILL_DOC},
+            tag=tag,
+            annotations=annotations,
+        )
+    return f"{registry}/{repo}:{tags[0]}"
+
+
+def test_describe_json_reports_all_curated_fields(
+    grim_at, project_dir: Path, registry: str, unique_repo: str
+) -> None:
+    ref = _publish(registry, unique_repo, annotations=FULL_ANNOTATIONS)
+    runner = grim_at(project_dir)
+    doc = runner.json("describe", ref)
+
+    # Single object (not an items envelope), every field present.
+    assert isinstance(doc, dict)
+    assert "items" not in doc and "error" not in doc
+    assert doc["kind"] == "skill"
+    assert doc["name"] == "describe-demo"
+    assert doc["title"] == "describe-demo"
+    assert doc["description"] == "Demo skill for describe tests."
+    assert doc["summary"] == "terse blurb"
+    assert doc["version"] == "1.2.0"
+    assert doc["license"] == "Apache-2.0"
+    assert doc["repository"] == "https://github.com/acme/describe-demo"
+    assert doc["keywords"] == ["review", "quality"], "split + trimmed"
+    assert doc["deprecated"] == "use acme/describe-demo-2"
+    assert doc["replaced_by"] == "ghcr.io/acme/skills/describe-demo-2"
+    assert doc["digest"].startswith("sha256:")
+    # The verbatim annotation map is carried whole.
+    assert doc["annotations"]["com.grimoire.replaced-by"] == "ghcr.io/acme/skills/describe-demo-2"
+    # git-provenance keys are absent here ⇒ explicit null (always-present policy).
+    assert doc["revision"] is None
+    assert doc["created"] is None
+
+
+def test_describe_bare_manifest_nulls_kind_not_error(
+    grim_at, project_dir: Path, registry: str, unique_repo: str
+) -> None:
+    """A foreign manifest (unrecognized kind, no grimoire annotations) does
+    not hard-error: kind is null and the curated fields fall to null."""
+    repo = f"{unique_repo}/mystery/opaque"
+    make_artifact(repo, "widget", {"opaque.md": "opaque\n"}, tag="latest")
+    runner = grim_at(project_dir)
+    doc = runner.json("describe", f"{registry}/{repo}:latest")
+
+    assert doc["kind"] is None, "unrecognized kind ⇒ null, no error"
+    assert doc["summary"] is None
+    assert doc["deprecated"] is None
+    assert doc["replaced_by"] is None
+    assert doc["keywords"] == [], "no keywords ⇒ empty array"
+    assert doc["tags"] == ["latest"]
+    assert doc["name"] == "opaque"
+
+
+def test_describe_lists_all_tags_sorted(
+    grim_at, project_dir: Path, registry: str, unique_repo: str
+) -> None:
+    ref = _publish(registry, unique_repo, tags=("latest", "1.0.0", "1.2.0"))
+    runner = grim_at(project_dir)
+    doc = runner.json("describe", ref)
+    assert doc["tags"] == ["1.0.0", "1.2.0", "latest"], "tags sorted"
+
+
+def test_describe_deprecated_and_replaced_by_together(
+    grim_at, project_dir: Path, registry: str, unique_repo: str
+) -> None:
+    """`deprecated` and `replaced_by` are independent and both surface."""
+    ref = _publish(
+        registry,
+        unique_repo,
+        annotations={
+            "com.grimoire.deprecated": "retired",
+            "com.grimoire.replaced-by": "ghcr.io/acme/skills/successor",
+        },
+    )
+    runner = grim_at(project_dir)
+    doc = runner.json("describe", ref)
+    assert doc["deprecated"] == "retired"
+    assert doc["replaced_by"] == "ghcr.io/acme/skills/successor"
+
+
+def test_describe_plain_is_key_value_table(
+    grim_at, project_dir: Path, registry: str, unique_repo: str
+) -> None:
+    ref = _publish(registry, unique_repo, tags=("latest", "1.0.0"), annotations=FULL_ANNOTATIONS)
+    runner = grim_at(project_dir)
+    out = runner.plain("describe", ref).stdout
+    assert out.splitlines()[0].startswith("Key"), "flat key/value table like grim context"
+    assert "skill" in out
+    assert "1.0.0,latest" in out, "tags comma-joined"
+
+
+def test_describe_offline_uncached_is_offline_blocked_81(
+    grim_at, project_dir: Path, registry: str, unique_repo: str
+) -> None:
+    """GRIM_OFFLINE=1 on an uncached reference is offline-blocked (81), an
+    error document on stdout — not a misleading not-found."""
+    ref = _publish(registry, unique_repo)
+    runner = grim_at(project_dir)
+    runner.env["GRIM_OFFLINE"] = "1"  # nothing is cached in the fresh grim_home
+    result = runner.run("--format", "json", "describe", ref, check=False)
+    assert result.returncode == 81, result.stderr
+    doc = json.loads(result.stdout)
+    assert doc["error"]["code"] == "offline-blocked"
+    assert doc["error"]["exit"] == 81
+
+
+def test_describe_unknown_flag_exits_64_without_json(
+    grim_at, project_dir: Path
+) -> None:
+    """A clap parse failure (unknown flag) is the pre-contract boundary:
+    exit 64, plain usage on stderr, no JSON error document on stdout."""
+    runner = grim_at(project_dir)
+    ref = f"localhost:5000/grim-test/{uuid.uuid4().hex[:12]}/skills/x:latest"
+    result = runner.run("--format", "json", "describe", ref, "--bogus", check=False)
+    assert result.returncode == 64
+    assert result.stdout == "", f"no JSON document before the parse boundary: {result.stdout!r}"
+    assert result.stderr.strip(), "clap usage message on stderr"

--- a/test/tests/test_describe.py
+++ b/test/tests/test_describe.py
@@ -7,7 +7,7 @@ import json
 import uuid
 from pathlib import Path
 
-from src.helpers import make_artifact
+from src.helpers import make_artifact, make_description
 
 
 SKILL_DOC = (
@@ -129,6 +129,32 @@ def test_describe_plain_is_key_value_table(
     assert out.splitlines()[0].startswith("Key"), "flat key/value table like grim context"
     assert "skill" in out
     assert "1.0.0,latest" in out, "tags comma-joined"
+
+
+def test_describe_has_description_true_when_companion_present(
+    grim_at, project_dir: Path, registry: str, unique_repo: str
+) -> None:
+    """`has_description` is true when the repository carries a `__grimoire`
+    companion — derived from the tag listing describe already fetches, and the
+    internal tag stays hidden from `tags[]`."""
+    repo = f"{unique_repo}/skills/describe-demo"
+    make_artifact(repo, "skill", {"describe-demo/SKILL.md": SKILL_DOC}, tag="latest")
+    make_description(repo, {"README.md": b"# Repo\n"})
+    runner = grim_at(project_dir)
+
+    doc = runner.json("describe", f"{registry}/{repo}:latest")
+    assert doc["has_description"] is True
+    assert "__grimoire" not in doc["tags"], "the internal companion tag stays hidden from tags[]"
+
+
+def test_describe_has_description_false_when_absent(
+    grim_at, project_dir: Path, registry: str, unique_repo: str
+) -> None:
+    """`has_description` is an always-present bool — false when no companion."""
+    ref = _publish(registry, unique_repo)
+    runner = grim_at(project_dir)
+    doc = runner.json("describe", ref)
+    assert doc["has_description"] is False
 
 
 def test_describe_offline_uncached_is_offline_blocked_81(

--- a/test/tests/test_fetch.py
+++ b/test/tests/test_fetch.py
@@ -148,6 +148,54 @@ def test_fetch_binary_path_is_base64_and_round_trips(
     assert "encoding" not in text_doc
 
 
+AGENT_DOC = (
+    "---\n"
+    "name: fetch-agent\n"
+    "description: Demo agent for fetch tests.\n"
+    "---\n"
+    "You review code.\n"
+)
+AGENT_README = "# Fetch Agent\n\nWhat this agent does.\n"
+
+
+def _publish_agent_with_readme(registry: str) -> str:
+    ns = f"grim-test/{uuid.uuid4().hex[:12]}"
+    repo = f"{ns}/agents/fetch-agent"
+    # An agent's well-known README rides the layer tree under `<name>/`,
+    # exactly like a skill's — a non-skill kind shipping a README.
+    make_artifact(
+        repo,
+        "agent",
+        {
+            "fetch-agent.md": AGENT_DOC,
+            "fetch-agent/README.md": AGENT_README,
+        },
+        tag="latest",
+    )
+    return f"{registry}/{repo}:latest"
+
+
+def test_fetch_agent_readme_listed_and_pullable(
+    grim_at, project_dir: Path, registry: str
+) -> None:
+    """A non-skill (agent) kind can ship a README that rides the layer tree:
+    it shows in `files[]` and pulls with `--path <name>/README.md`, the same
+    path shape every tree-backed kind uses. This is the contract the VS Code
+    extension's details tab relies on."""
+    ref = _publish_agent_with_readme(registry)
+    runner = grim_at(project_dir)
+
+    doc = runner.json("fetch", ref)
+    assert doc["kind"] == "agent"
+    paths = [f["path"] for f in doc["files"]]
+    assert "fetch-agent.md" in paths
+    assert "fetch-agent/README.md" in paths
+
+    result = runner.plain("fetch", ref, "--path", "fetch-agent/README.md")
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == AGENT_README
+
+
 def test_fetch_large_content_is_not_truncated(
     grim_at, project_dir: Path, registry: str
 ) -> None:

--- a/test/tests/test_fetch.py
+++ b/test/tests/test_fetch.py
@@ -3,7 +3,9 @@
 """`grim fetch` acceptance tests — use != install, payload-plain stdout."""
 from __future__ import annotations
 
+import base64
 import json
+import subprocess
 import uuid
 from pathlib import Path
 
@@ -94,6 +96,56 @@ def test_fetch_bundle_vendor_and_unknown_vendor_error(
     ref = _publish_skill(registry)
     result = runner.plain("fetch", ref, "--vendor", "nonesuch", check=False)
     assert result.returncode != 0
+
+
+# A minimal but non-UTF-8 payload (PNG signature + a 0xFF byte).
+LOGO_BYTES = bytes([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0xFF, 0xFE])
+
+
+def _publish_skill_with_logo(registry: str) -> str:
+    ns = f"grim-test/{uuid.uuid4().hex[:12]}"
+    repo = f"{ns}/skills/logo-demo"
+    make_artifact(
+        repo,
+        "skill",
+        {
+            "logo-demo/SKILL.md": "---\nname: logo-demo\ndescription: d.\n---\n# Logo\n",
+            "logo-demo/assets/logo.png": LOGO_BYTES,
+        },
+        tag="latest",
+    )
+    return f"{registry}/{repo}:latest"
+
+
+def test_fetch_binary_path_is_base64_and_round_trips(
+    grim_at, project_dir: Path, registry: str
+) -> None:
+    """A binary --path support file comes back base64 (`encoding: "base64"`)
+    in JSON, and plain output decodes back to the exact bytes so a stdout
+    redirect round-trips byte-identical."""
+    ref = _publish_skill_with_logo(registry)
+    runner = grim_at(project_dir)
+
+    doc = runner.json("fetch", ref, "--path", "logo-demo/assets/logo.png")
+    assert doc["encoding"] == "base64"
+    assert base64.b64decode(doc["content"]) == LOGO_BYTES
+    assert doc.get("truncated") is not True
+
+    # Plain redirect (binary): capture stdout to a file and compare bytes.
+    out_file = project_dir / "logo.png"
+    with out_file.open("wb") as fh:
+        subprocess.run(
+            [str(runner.binary), "fetch", ref, "--path", "logo-demo/assets/logo.png"],
+            stdout=fh,
+            env=runner.env,
+            cwd=str(project_dir),
+            check=True,
+        )
+    assert out_file.read_bytes() == LOGO_BYTES, "redirect round-trips byte-identical"
+
+    # A UTF-8 support file is unchanged — no encoding field.
+    text_doc = runner.json("fetch", ref, "--path", "logo-demo/SKILL.md")
+    assert "encoding" not in text_doc
 
 
 def test_fetch_large_content_is_not_truncated(

--- a/test/tests/test_fetch.py
+++ b/test/tests/test_fetch.py
@@ -9,7 +9,7 @@ import subprocess
 import uuid
 from pathlib import Path
 
-from src.helpers import make_artifact, make_bundle
+from src.helpers import make_artifact, make_bundle, make_description
 
 
 SKILL_DOC = (
@@ -215,3 +215,136 @@ def test_fetch_large_content_is_not_truncated(
 
     parsed = json.loads(runner.run("fetch", f"{registry}/{repo}:latest", format="json").stdout)
     assert parsed.get("truncated") is not True
+
+
+# --------------------------------------------------------------------------
+# Description companion + digest probe (the VS Code details-tab surface)
+# --------------------------------------------------------------------------
+
+README_BYTES = b"# Repo\n\nWhat this repository ships.\n"
+
+
+def _publish_with_companion(registry: str) -> str:
+    """Publish an artifact and its description companion; return the artifact
+    ref (grim retargets the reserved ``__grimoire`` tag itself)."""
+    ns = f"grim-test/{uuid.uuid4().hex[:12]}"
+    repo = f"{ns}/skills/desc-demo"
+    make_artifact(
+        repo,
+        "skill",
+        {"desc-demo/SKILL.md": "---\nname: desc-demo\ndescription: d.\n---\n# d\n"},
+        tag="latest",
+    )
+    make_description(repo, {"README.md": README_BYTES, "assets/logo.png": LOGO_BYTES})
+    return f"{registry}/{repo}:latest"
+
+
+def test_fetch_description_json_inlines_all_members(
+    grim_at, project_dir: Path, registry: str
+) -> None:
+    """`fetch --description` returns `{ref, digest, kind: "desc", files: [...]}`
+    with every member inline: text verbatim, binary as base64."""
+    ref = _publish_with_companion(registry)
+    runner = grim_at(project_dir)
+
+    doc = runner.json("fetch", ref, "--description")
+    assert doc["kind"] == "desc"
+    assert doc["ref"].endswith(":__grimoire"), doc["ref"]
+    assert doc["digest"].startswith("sha256:")
+    members = {f["path"]: f for f in doc["files"]}
+
+    readme = members["README.md"]
+    assert readme["content"].encode() == README_BYTES
+    assert "encoding" not in readme, "a text member carries no encoding field"
+
+    logo = members["assets/logo.png"]
+    assert logo["encoding"] == "base64"
+    assert base64.b64decode(logo["content"]) == LOGO_BYTES
+
+
+def test_fetch_description_out_round_trips_the_tree(
+    grim_at, project_dir: Path, registry: str
+) -> None:
+    """`fetch --description --out <dir>` unpacks the companion tree to disk
+    byte-identical; plain stdout stays empty (no single payload)."""
+    ref = _publish_with_companion(registry)
+    runner = grim_at(project_dir)
+
+    out_dir = project_dir / "desc-out"
+    result = runner.plain("fetch", ref, "--description", "--out", str(out_dir))
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == "", "a multi-file bundle has no single plain payload"
+
+    assert (out_dir / "README.md").read_bytes() == README_BYTES
+    assert (out_dir / "assets" / "logo.png").read_bytes() == LOGO_BYTES
+
+
+def test_fetch_digest_only_matches_full_fetch_for_artifact_and_companion(
+    grim_at, project_dir: Path, registry: str
+) -> None:
+    """`--digest-only` resolves without downloading and returns `{ref, digest}`;
+    the digest equals the full fetch's digest, for the artifact and (with
+    `--description`) the companion."""
+    ref = _publish_with_companion(registry)
+    # A resolved project scope keeps the probe to its minimal shape (a degraded
+    # scope would add a `warnings` note, like every fetch report).
+    (project_dir / "grimoire.toml").write_text("[skills]\n")
+    runner = grim_at(project_dir)
+
+    # Artifact.
+    full = runner.json("fetch", ref)
+    probe = runner.json("fetch", ref, "--digest-only")
+    assert set(probe) == {"ref", "digest"}, f"digest probe is just {{ref, digest}}: {probe}"
+    assert probe["digest"] == full["digest"]
+
+    # Companion.
+    full_desc = runner.json("fetch", ref, "--description")
+    probe_desc = runner.json("fetch", ref, "--description", "--digest-only")
+    assert probe_desc["digest"] == full_desc["digest"]
+    assert probe_desc["ref"].endswith(":__grimoire")
+    assert probe["digest"] != probe_desc["digest"], "artifact and companion are distinct manifests"
+
+
+def test_fetch_missing_companion_is_not_found_79(
+    grim_at, project_dir: Path, registry: str
+) -> None:
+    """`--description` on a repo with no companion is a not-found (79) — the
+    standard error envelope, parity with a missing `grim fetch`."""
+    ns = f"grim-test/{uuid.uuid4().hex[:12]}"
+    repo = f"{ns}/skills/lonely"
+    make_artifact(repo, "skill", {"lonely/SKILL.md": "---\nname: lonely\ndescription: d.\n---\n# x\n"}, tag="latest")
+    runner = grim_at(project_dir)
+
+    result = runner.run("--format", "json", "fetch", f"{registry}/{repo}:latest", "--description", check=False)
+    assert result.returncode == 79, result.stderr
+    doc = json.loads(result.stdout)
+    assert doc["error"]["code"] == "not-found"
+    assert doc["error"]["exit"] == 79
+
+
+def test_fetch_flag_combination_usage_errors_exit_64(
+    grim_at, project_dir: Path, registry: str
+) -> None:
+    """The contradictory flag combinations are usage errors (64) before any
+    resolution: `--out` without `--description`, download flags with
+    `--digest-only`, and plain `--description` without `--out`."""
+    ref = _publish_with_companion(registry)
+    runner = grim_at(project_dir)
+
+    # --out requires --description.
+    r1 = runner.plain("fetch", ref, "--out", str(project_dir / "o"), check=False)
+    assert r1.returncode == 64, r1.stderr
+
+    # --digest-only downloads nothing, so it takes no content flag.
+    for extra in (("--path", "README.md"), ("--vendor", "claude"), ("--out", str(project_dir / "o2"))):
+        r = runner.plain("fetch", ref, "--digest-only", *extra, check=False)
+        assert r.returncode == 64, f"--digest-only {extra} must be a usage error; stderr: {r.stderr}"
+
+    # Plain --description without --out has no single payload to print.
+    r3 = runner.plain("fetch", ref, "--description", check=False)
+    assert r3.returncode == 64, r3.stderr
+    assert "--out" in r3.stderr or "json" in r3.stderr, r3.stderr
+
+    # ...but --format json is fine without --out.
+    ok = runner.run("--format", "json", "fetch", ref, "--description", check=False)
+    assert ok.returncode == 0, ok.stderr

--- a/test/tests/test_index_source.py
+++ b/test/tests/test_index_source.py
@@ -30,8 +30,15 @@ import pytest
 # ---------------------------------------------------------------------------
 
 
-def _package(name: str, kind: str, ref: str, description: str) -> dict:
-    return {
+def _package(
+    name: str,
+    kind: str,
+    ref: str,
+    description: str,
+    keywords: list[str] | None = None,
+    summary: str | None = None,
+) -> dict:
+    pkg = {
         "schema": 1,
         "name": name,
         "kind": kind,
@@ -40,6 +47,13 @@ def _package(name: str, kind: str, ref: str, description: str) -> dict:
         "repository": "https://github.com/acme/skills",
         "owner": {"github": "acme", "id": 1},
     }
+    # Omit-empty, mirroring the announce writer: pre-search-metadata
+    # pointers carry neither key.
+    if keywords:
+        pkg["keywords"] = keywords
+    if summary is not None:
+        pkg["summary"] = summary
+    return pkg
 
 
 @pytest.fixture()
@@ -150,6 +164,34 @@ def test_search_http_index_filters_by_query(grim_at, project_dir: Path, http_ind
     assert result.returncode == 0, result.stderr
     repos = [r.get("repo", "") for r in json.loads(result.stdout)["items"]]
     assert repos == ["ghcr.io/acme/skills/alpha-skill"], f"got {repos}"
+
+
+def test_search_http_index_matches_by_keyword(grim_at, project_dir: Path, http_index) -> None:
+    """A query term present only in an index pointer's ``keywords`` (never in
+    the repo name or description) still matches — the index now carries the
+    search metadata the phone book used to drop."""
+    root, base = http_index
+    _write_all_json(
+        root,
+        [
+            _package(
+                "grim",
+                "mcp",
+                "ghcr.io/grimoire-rs/mcp/grim",
+                "The grimoire MCP server",
+                keywords=["catalog", "fetch", "render"],
+                summary="Drive grim from an agent",
+            ),
+            _package("other", "skill", "ghcr.io/acme/skills/other", "Unrelated"),
+        ],
+    )
+    _index_config(project_dir, base)
+
+    runner = grim_at(project_dir)
+    result = runner.run("--format", "json", "search", "--refresh", "fetch", check=False)
+    assert result.returncode == 0, result.stderr
+    repos = [r.get("repo", "") for r in json.loads(result.stdout)["items"]]
+    assert repos == ["ghcr.io/grimoire-rs/mcp/grim"], f"keyword-only match failed: {repos}"
 
 
 def test_search_unreachable_http_index_degrades_to_empty(grim_at, project_dir: Path) -> None:

--- a/test/tests/test_json_interface.py
+++ b/test/tests/test_json_interface.py
@@ -157,6 +157,39 @@ def test_search_surfaces_null_kind_for_unrecognized_manifest(
     assert entry["kind"] is None
 
 
+def test_describe_is_single_object_with_all_fields_present(
+    grim_at, project_dir: Path, registry: str, unique_repo: str
+) -> None:
+    """`describe` is a single flat object (no `items` envelope, no `error`
+    key); every field is always present, `null` when absent (`revision` /
+    `created` here), and `keywords`/`tags` are arrays, `annotations` a map —
+    the single-object null policy."""
+    repo = f"{unique_repo}/skills/desc"
+    make_artifact(
+        repo,
+        "skill",
+        {"desc/SKILL.md": "---\nname: desc\ndescription: d\n---\n# d\n"},
+        tag="latest",
+        annotations={"com.grimoire.replaced-by": "ghcr.io/acme/skills/desc-2"},
+    )
+    runner = grim_at(project_dir)
+
+    doc = runner.json("describe", f"{registry}/{repo}:latest")
+    assert isinstance(doc, dict)
+    assert "items" not in doc and "error" not in doc
+    for key in (
+        "ref", "digest", "kind", "name", "title", "description", "summary",
+        "version", "license", "repository", "revision", "created", "keywords",
+        "deprecated", "replaced_by", "tags", "annotations",
+    ):
+        assert key in doc, f"single-object report must always carry {key}"
+    assert doc["revision"] is None and doc["created"] is None
+    assert isinstance(doc["keywords"], list)
+    assert isinstance(doc["tags"], list)
+    assert isinstance(doc["annotations"], dict)
+    assert doc["replaced_by"] == "ghcr.io/acme/skills/desc-2"
+
+
 def test_mcp_and_cli_status_share_data_but_differ_in_bytes(
     grim_at, project_dir: Path
 ) -> None:

--- a/test/tests/test_json_interface.py
+++ b/test/tests/test_json_interface.py
@@ -15,7 +15,7 @@ import json
 import subprocess
 from pathlib import Path
 
-from src.helpers import make_artifact, write_config
+from src.helpers import make_artifact, make_description, write_config
 from src.registry import REGISTRY_HOST
 
 _PROTOCOL = "2025-06-18"
@@ -217,16 +217,49 @@ def test_describe_is_single_object_with_all_fields_present(
     assert isinstance(doc, dict)
     assert "items" not in doc and "error" not in doc
     for key in (
-        "ref", "digest", "kind", "name", "title", "description", "summary",
-        "version", "license", "repository", "revision", "created", "keywords",
-        "deprecated", "replaced_by", "tags", "annotations",
+        "ref", "digest", "kind", "name", "title", "description",
+        "has_description", "summary", "version", "license", "repository",
+        "revision", "created", "keywords", "deprecated", "replaced_by",
+        "tags", "annotations",
     ):
         assert key in doc, f"single-object report must always carry {key}"
     assert doc["revision"] is None and doc["created"] is None
+    assert isinstance(doc["has_description"], bool), "companion presence is an always-present bool"
     assert isinstance(doc["keywords"], list)
     assert isinstance(doc["tags"], list)
     assert isinstance(doc["annotations"], dict)
     assert doc["replaced_by"] == "ghcr.io/acme/skills/desc-2"
+
+
+def test_fetch_report_is_tri_shaped(
+    grim_at, project_dir: Path, registry: str, unique_repo: str
+) -> None:
+    """`fetch` JSON has three documented shapes: content (`{ref, digest, kind,
+    …, content}`), a description bundle (`{ref, digest, kind: "desc",
+    files[]}`), and a digest probe (`{ref, digest}` only). Each is a flat
+    object, never an `items` envelope or `error` key."""
+    repo = f"{unique_repo}/skills/tri"
+    make_artifact(
+        repo, "skill", {"tri/SKILL.md": "---\nname: tri\ndescription: d.\n---\n# t\n"}, tag="latest"
+    )
+    make_description(repo, {"README.md": b"# Repo\n"})
+    # A resolved project scope keeps the digest probe to its minimal shape.
+    (project_dir / "grimoire.toml").write_text("[skills]\n")
+    runner = grim_at(project_dir)
+    ref = f"{registry}/{repo}:latest"
+
+    content = runner.json("fetch", ref)
+    assert "items" not in content and "error" not in content
+    assert content["kind"] == "skill" and "content" in content
+
+    bundle = runner.json("fetch", ref, "--description")
+    assert bundle["kind"] == "desc"
+    assert isinstance(bundle["files"], list) and bundle["files"]
+    assert {"path", "size", "content"} <= set(bundle["files"][0])
+
+    probe = runner.json("fetch", ref, "--digest-only")
+    assert set(probe) == {"ref", "digest"}, f"digest probe is exactly {{ref, digest}}: {probe}"
+    assert probe["digest"] == content["digest"], "the probe digest equals the full fetch digest"
 
 
 def test_mcp_and_cli_status_share_data_but_differ_in_bytes(

--- a/test/tests/test_json_interface.py
+++ b/test/tests/test_json_interface.py
@@ -38,6 +38,9 @@ def test_error_document_on_missing_config(
     assert doc["error"]["code"] == "not-found"
     assert doc["error"]["exit"] == 79
     assert doc["error"]["message"], "message carries the rendered chain"
+    assert "reason" not in doc["error"], (
+        f"an unclassified error omits the optional reason subtype: {doc}"
+    )
     assert result.stderr.strip(), "human-readable chain still on stderr"
 
 
@@ -57,6 +60,42 @@ def test_error_document_on_usage_error(
     doc = json.loads(result.stdout)
     assert doc["error"]["code"] == "usage"
     assert doc["error"]["exit"] == 64
+    assert "reason" not in doc["error"], "a usage error carries no reason subtype"
+
+
+def test_error_reason_marks_stale_lock(grim_at, project_dir: Path) -> None:
+    """The error document carries a machine-readable ``reason`` for the
+    stale-lock refusal, so a consumer detects it without scraping the
+    non-frozen ``message``.
+
+    The partial-resolve guard (``resolve_lock_partial``,
+    ``src/resolve/resolver.rs``) runs BEFORE any registry I/O, so a
+    hand-crafted lock whose ``declaration_hash`` deliberately mismatches the
+    declared set triggers the refusal fully offline — no registry needed.
+    """
+    write_config(
+        project_dir, skills={"code-review": "ghcr.io/acme/code-review:stable"}
+    )
+    # A valid lock whose all-zero declaration_hash cannot match the real
+    # canonicalized hash of the declaration above.
+    (project_dir / "grimoire.lock").write_text(
+        "[metadata]\n"
+        "lock_version = 1\n"
+        "declaration_hash_version = 1\n"
+        f'declaration_hash = "sha256:{"0" * 64}"\n'
+        'generated_by = "grim test"\n'
+        'generated_at = "2026-01-01T00:00:00Z"\n'
+    )
+    runner = grim_at(project_dir)
+
+    result = runner.run(
+        "--offline", "--format", "json", "update", "code-review", check=False
+    )
+    assert result.returncode == 65, result.stderr
+    doc = json.loads(result.stdout)
+    assert doc["error"]["code"] == "data"
+    assert doc["error"]["exit"] == 65
+    assert doc["error"]["reason"] == "stale-lock"
 
 
 def test_plain_mode_failure_keeps_stdout_empty(

--- a/test/tests/test_mcp.py
+++ b/test/tests/test_mcp.py
@@ -188,6 +188,52 @@ def test_mcp_status_tool_returns_payload(
     )
 
 
+def test_mcp_describe_tool_matches_cli_json(
+    grim_at: Callable[[Path], GrimRunner],
+    project_dir: Path,
+    registry: str,
+    unique_repo: str,
+) -> None:
+    """``grim_describe`` MCP tool returns the same payload as
+    ``grim describe --format json`` for the same reference. Both route
+    through ``fetch::describe_artifact``; one source of truth. Needs the
+    network (a manifest lookup), so the server runs non-offline."""
+    repo = f"{unique_repo}/skills/mcp-desc"
+    make_artifact(
+        repo,
+        "skill",
+        {"mcp-desc/SKILL.md": "---\nname: mcp-desc\ndescription: d\n---\n# d\n"},
+        tag="latest",
+        annotations={"com.grimoire.replaced-by": "ghcr.io/acme/skills/mcp-desc-2"},
+    )
+    (project_dir / "grimoire.toml").write_text("[skills]\n")
+    runner = grim_at(project_dir)
+    ref = f"{registry}/{repo}:latest"
+
+    responses = _drive(
+        runner,
+        project_dir,
+        [
+            _initialize(1),
+            {"jsonrpc": "2.0", "method": "notifications/initialized"},
+            {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/call",
+                "params": {"name": "grim_describe", "arguments": {"ref": ref}},
+            },
+        ],
+        offline=False,
+    )
+
+    call = responses[2]["result"]
+    assert call["isError"] is False, f"grim_describe must not error: {call!r}"
+    mcp_payload = json.loads(call["content"][0]["text"])
+    cli_payload = runner.json("describe", ref)
+    assert mcp_payload == cli_payload, "MCP grim_describe must equal CLI describe --format json"
+    assert mcp_payload["replaced_by"] == "ghcr.io/acme/skills/mcp-desc-2"
+
+
 def test_mcp_allow_writes_gates_grim_render(
     grim_at: Callable[[Path], GrimRunner], project_dir: Path
 ) -> None:
@@ -208,7 +254,7 @@ def test_mcp_allow_writes_gates_grim_render(
         {"jsonrpc": "2.0", "id": 2, "method": "tools/list"},
     ]
 
-    read_only = {"grim_search", "grim_status", "grim_fetch"}
+    read_only = {"grim_search", "grim_status", "grim_fetch", "grim_describe"}
 
     read_only_responses = _drive(runner, project_dir, list_request, allow_writes=False)
     read_only_names = {t["name"] for t in read_only_responses[2]["result"]["tools"]}

--- a/test/tests/test_mcp.py
+++ b/test/tests/test_mcp.py
@@ -16,7 +16,7 @@ import uuid
 from collections.abc import Callable
 from pathlib import Path
 
-from src.helpers import make_artifact
+from src.helpers import make_artifact, make_description
 from src.registry import REGISTRY_HOST
 from src.runner import GrimRunner
 
@@ -232,6 +232,68 @@ def test_mcp_describe_tool_matches_cli_json(
     cli_payload = runner.json("describe", ref)
     assert mcp_payload == cli_payload, "MCP grim_describe must equal CLI describe --format json"
     assert mcp_payload["replaced_by"] == "ghcr.io/acme/skills/mcp-desc-2"
+
+
+def test_mcp_fetch_description_and_digest_only_match_cli(
+    grim_at: Callable[[Path], GrimRunner],
+    project_dir: Path,
+    registry: str,
+    unique_repo: str,
+) -> None:
+    """``grim_fetch`` accepts the new ``description`` / ``digest_only`` args and
+    returns the same payloads as the equivalent CLI ``grim fetch`` calls — the
+    tri-shaped outcome routes through one core (``fetch::fetch_outcome``), so
+    MCP and CLI never drift. Needs the network (manifest + layer), so the
+    server runs non-offline."""
+    repo = f"{unique_repo}/skills/mcp-desc-fetch"
+    make_artifact(
+        repo,
+        "skill",
+        {"mcp-desc-fetch/SKILL.md": "---\nname: mcp-desc-fetch\ndescription: d\n---\n# d\n"},
+        tag="latest",
+    )
+    make_description(repo, {"README.md": b"# Repo\n", "assets/logo.png": bytes([0x89, 0x50, 0x4E, 0x47, 0x00, 0xFF])})
+    (project_dir / "grimoire.toml").write_text("[skills]\n")
+    runner = grim_at(project_dir)
+    ref = f"{registry}/{repo}:latest"
+
+    responses = _drive(
+        runner,
+        project_dir,
+        [
+            _initialize(1),
+            {"jsonrpc": "2.0", "method": "notifications/initialized"},
+            {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/call",
+                "params": {"name": "grim_fetch", "arguments": {"ref": ref, "description": True}},
+            },
+            {
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "tools/call",
+                "params": {"name": "grim_fetch", "arguments": {"ref": ref, "digest_only": True}},
+            },
+        ],
+        offline=False,
+    )
+
+    desc_call = responses[2]["result"]
+    assert desc_call["isError"] is False, f"grim_fetch --description must not error: {desc_call!r}"
+    desc_payload = json.loads(desc_call["content"][0]["text"])
+    assert desc_payload["kind"] == "desc"
+    assert desc_payload == runner.json("fetch", ref, "--description"), (
+        "MCP grim_fetch(description) must equal CLI fetch --description --format json"
+    )
+
+    probe_call = responses[3]["result"]
+    assert probe_call["isError"] is False, f"grim_fetch --digest-only must not error: {probe_call!r}"
+    probe_payload = json.loads(probe_call["content"][0]["text"])
+    assert set(probe_payload) == {"ref", "digest"}
+    assert probe_payload == runner.json("fetch", ref, "--digest-only"), (
+        "MCP grim_fetch(digest_only) must equal CLI fetch --digest-only --format json"
+    )
 
 
 def test_mcp_allow_writes_gates_grim_render(

--- a/test/tests/test_publish_announce.py
+++ b/test/tests/test_publish_announce.py
@@ -43,11 +43,22 @@ def _write(p: Path, body: str) -> None:
     p.write_text(body)
 
 
-def _make_skill_source(project_dir: Path, name: str, description: str) -> None:
+def _make_skill_source(
+    project_dir: Path,
+    name: str,
+    description: str,
+    keywords: str | None = None,
+    summary: str | None = None,
+) -> None:
+    meta = f"  repository: https://github.com/acme/{name}\n"
+    if keywords is not None:
+        meta += f"  keywords: {keywords}\n"
+    if summary is not None:
+        meta += f"  summary: {summary}\n"
     _write(
         project_dir / "skills" / name / "SKILL.md",
         f"---\nname: {name}\ndescription: {description}\n"
-        f"metadata:\n  repository: https://github.com/acme/{name}\n---\n# {name}\n",
+        f"metadata:\n{meta}---\n# {name}\n",
     )
 
 
@@ -238,6 +249,29 @@ def test_publish_announce_pushes_branch_with_metadata(
     assert meta["description"] == "Announce me."
     assert meta["owner"] == {"login": "acme", "id": 42}
     assert meta["repository"] == f"https://github.com/acme/{name}"
+
+
+def test_publish_announce_carries_keywords_and_summary(
+    grim_at, project_dir: Path, registry: str, tmp_path: Path
+) -> None:
+    """A skill published with metadata.keywords / metadata.summary announces
+    a pointer that carries them, so an index-backed `grim search` can match
+    them (a skill without those fields writes neither key)."""
+    ns = f"grim-test/{uuid.uuid4().hex[:12]}"
+    name = "ann-kw"
+    _make_skill_source(project_dir, name, "Announce me.", keywords="review, quality", summary="Terse review")
+    _manifest(project_dir, ns, name, INDEX_URL)
+
+    runner = grim_at(project_dir)
+    bare = _index_remote(tmp_path, runner)
+    result = runner.run("publish", "--announce", check=False)
+    assert result.returncode == 0, f"publish --announce failed: {result.stderr}"
+
+    branch = _announce_branch(bare)
+    blob = _git(bare, "show", f"{branch}:index/{INDEX_HOST}/acme/{name}/metadata.json")
+    meta = json.loads(blob)
+    assert meta["keywords"] == ["review", "quality"], meta
+    assert meta["summary"] == "Terse review", meta
 
 
 def test_publish_announce_is_repeatable(

--- a/test/tests/test_search.py
+++ b/test/tests/test_search.py
@@ -153,6 +153,40 @@ def test_search_exposes_repository_url_with_https_guard(
     assert legacy["repository"] is None, "non-URL source ref must be dropped"
 
 
+def test_search_surfaces_replaced_by(
+    grim_at, project_dir: Path, registry: str, unique_repo: str
+) -> None:
+    """`com.grimoire.replaced-by` surfaces as the JSON `replaced_by` field
+    (always present — null when the artifact names no successor)."""
+    make_artifact(
+        f"{unique_repo}/superseded",
+        "skill",
+        {"superseded/SKILL.md": "---\nname: superseded\n---\n# S\n"},
+        tag="latest",
+        annotations={"com.grimoire.replaced-by": "ghcr.io/acme/skills/successor"},
+    )
+    make_artifact(
+        f"{unique_repo}/current",
+        "skill",
+        {"current/SKILL.md": "---\nname: current\n---\n# C\n"},
+        tag="latest",
+    )
+    runner = grim_at(project_dir)
+
+    rows = runner.json(
+        "search", unique_repo, "--registry", f"{REGISTRY_HOST}/{unique_repo}", "--refresh"
+    )["items"]
+    by_repo = {r["repo"]: r for r in rows}
+    superseded = next(
+        v for k, v in by_repo.items() if k.endswith(f"{unique_repo}/superseded")
+    )
+    current = next(
+        v for k, v in by_repo.items() if k.endswith(f"{unique_repo}/current")
+    )
+    assert superseded["replaced_by"] == "ghcr.io/acme/skills/successor"
+    assert current["replaced_by"] is None, "always-present null when no replacement"
+
+
 def test_search_query_miss_is_empty_array_exit_0(
     grim_at, project_dir: Path, registry: str, unique_repo: str
 ) -> None:


### PR DESCRIPTION
## Summary

Additive CLI surface for the new VS Code extension ([grimoire-vscode](https://github.com/grimoire-rs/grimoire-vscode)). All changes follow the frozen JSON interface's additive-only policy.

- **`grim describe <REFERENCE>`** — manifest-level metadata without a blob download: curated fields (title, description, summary, version, license, repository, revision, created, keywords, deprecated, replaced_by), the full sorted tag list, and the verbatim annotation map. Uses `Operation::Resolve` so offline misses surface as `offline-blocked` (81), not a fake not-found.
- **`grim fetch --path` base64** — binary support files (e.g. `logo.png`) are returned base64-encoded with an additive `encoding: "base64"` field; plain mode decodes back to raw bytes so `grim fetch ref --path x/logo.png > logo.png` round-trips byte-identical. Oversize binaries still error (base64 is never truncated).
- **`com.grimoire.replaced-by`** — deprecation companion annotation, authored via `metadata.replaced-by` (skill/agent), rule frontmatter, or bundle TOML; validated as an `Identifier` at build time (exit 65); surfaced in `search` (`replaced_by`, field 12) and `describe`.
- **MCP `grim_describe`** tool — same core, payload equals the CLI JSON.
- Docs: json-interface, commands, mcp-servers, publishing/artifacts (well-known `README.md` / `logo.png|svg` asset convention — these already ride the layer tree, no packing changes needed). Catalog skills updated.

## Testing

- `task rust:verify` green: 1596 unit tests, clippy/fmt/license clean
- Acceptance against a local registry: 48 new/extended (test_describe.py + fetch/search/json_interface/mcp) + 65 regression tests, all passing
- Cross-verified end-to-end from the VS Code extension: describe (ghcr.io + local registry), replaced_by round-trip, logo → base64 → valid PNG data URI

Closes the "describe README.md + logo" and "deprecated replaced-by" TODO items.