### PR TITLE
docs: give grimoire.rs a share preview, canonical URLs, and a sitemap

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -55,10 +55,13 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Setup Task
         uses: go-task/setup-task@01a4adf9db2d14c1de7a560f09170b6e0df736aa # v2.1.0
+      # Pinned to 0.5.3: docs/theme/index.hbs vendors that release's stock
+      # index.hbs byte for byte. Bumping the pin needs a re-copy via
+      # `mdbook init --theme` and a re-diff, or it silently drifts from upstream.
       - name: Install mdBook
         uses: taiki-e/install-action@2ca9b94c269419b7b0c711c09d0b21c4e1d51145 # v2.83.1
         with:
-          tool: mdbook
+          tool: mdbook@0.5.3
       # Builds grim, regenerates docs/src/schemas/*.json from the parser,
       # then builds the book — so the published schemas always match grim.
       - name: Build the book

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -43,6 +43,11 @@ jobs:
           # `external/docker_credential` is the [patch.crates-io] source; the
           # grim build (needed to generate the schemas) fails without it.
           submodules: recursive
+          # `.gitattributes` tracks `*.png` in LFS, and `docs/src/og-card.png`
+          # is the social preview every share link renders. Without this the
+          # checkout leaves a pointer file, mdBook copies the pointer text
+          # through, and the card 404s as an image everywhere it is unfurled.
+          lfs: true
       - name: Configure Pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
       - name: Setup Rust

--- a/assets/og-card.html
+++ b/assets/og-card.html
@@ -1,0 +1,101 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Grimoire — A lockfile for your AI-agent config.</title>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  html, body {
+    width: 1280px;
+    height: 640px;
+    overflow: hidden;
+    background: #161826;
+    font-family: -apple-system, "Segoe UI", system-ui, Roboto, Helvetica, Arial, sans-serif;
+  }
+  .card {
+    position: relative;
+    width: 1280px;
+    height: 640px;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    padding: 76px 92px;
+  }
+  /* faint violet glow behind the mark — accent stays a hairline/glow, never a filled panel */
+  .glow {
+    position: absolute;
+    top: -160px;
+    left: -160px;
+    width: 560px;
+    height: 560px;
+    background: radial-gradient(circle, rgba(145, 132, 217, 0.28) 0%, rgba(145, 132, 217, 0) 70%);
+    pointer-events: none;
+  }
+  .brand {
+    position: relative;
+    display: flex;
+    align-items: center;
+    gap: 22px;
+  }
+  .brand svg { width: 68px; height: 68px; flex-shrink: 0; }
+  .wordmark {
+    font-size: 34px;
+    font-weight: 700;
+    color: #d2cefd;
+    letter-spacing: 0.01em;
+  }
+  .headline {
+    position: relative;
+    font-size: 92px;
+    font-weight: 800;
+    line-height: 1.12;
+    letter-spacing: -0.02em;
+    color: #e9e9ed;
+    max-width: 1060px;
+    text-wrap: balance;
+  }
+  .foot {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+  }
+  .foot span {
+    font-size: 24px;
+    font-weight: 600;
+    color: #9184d9;
+    letter-spacing: 0.03em;
+  }
+  /* hairline, not a panel */
+  .hairline {
+    position: absolute;
+    left: 92px;
+    right: 92px;
+    bottom: 132px;
+    height: 1px;
+    background: rgba(145, 132, 217, 0.25);
+  }
+</style>
+</head>
+<body>
+  <div class="card">
+    <div class="glow"></div>
+    <div class="brand">
+      <svg viewBox="0 0 128 128" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Grimoire logo">
+        <g transform="matrix(1.0668848,0,0,1.0668848,-4.2806272,4.7878936)">
+          <path fill="#ffb02e" d="M 64,5 Q 68.5,25.5 90,30 68.5,34.5 64,55 59.5,34.5 38,30 59.5,25.5 64,5 Z" />
+          <path fill="#ffb02e" d="m 99,8 q 1.8,7.2 9,9 -7.2,1.8 -9,9 -1.8,-7.2 -9,-9 7.2,-1.8 9,-9 z" />
+          <path fill="#ffb02e" d="m 29,16 q 1.2,4.8 6,6 -4.8,1.2 -6,6 -1.2,-4.8 -6,-6 4.8,-1.2 6,-6 z" />
+          <path fill="#6d52f4" d="M 16,60 C 32,54 50,58 64,68 78,58 96,54 112,60 V 98 C 96,92 78,96 64,106 50,96 32,92 16,98 Z" />
+          <path fill="#dcd2fc" d="m 24,66 c 12,-4 26,-1 40,8 14,-9 28,-12 40,-8 V 92 C 92,88 78,90 64,98 50,90 36,88 24,92 Z" />
+          <path d="M 64,78 V 94" stroke="#6d52f4" stroke-width="3.5" stroke-linecap="round" fill="none" />
+        </g>
+      </svg>
+      <span class="wordmark">Grimoire</span>
+    </div>
+    <div class="headline">A lockfile for your AI-agent config.</div>
+    <div class="hairline"></div>
+    <div class="foot"><span>grimoire.rs</span></div>
+  </div>
+</body>
+</html>

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,9 +11,21 @@ The user-facing documentation site, built with [mdBook][mdbook].
 Build and preview locally:
 
 ```sh
-cargo install mdbook
-mdbook serve docs --open
+cargo install mdbook --version 0.5.3
+task docs:serve
 ```
+
+The version is pinned here for the same reason it is pinned in CI:
+`theme/index.hbs` vendors mdBook 0.5.3's stock template in its non-landing
+branch. Raising it means re-copying that template from `mdbook init --theme`
+and re-diffing — see the comment on the pin in
+[`.github/workflows/docs.yml`](../.github/workflows/docs.yml).
+
+Prefer the task over a bare `mdbook` call: it regenerates the JSON Schemas
+under `src/schemas/` from grim's parse structs first, so a preview never
+serves schemas that disagree with the binary. `task docs:build` additionally
+runs [`seo.py`](./seo.py) over the built site; `docs:serve` deliberately does
+not, so a local preview carries no canonical or Open Graph tags.
 
 Writing conventions live in `.claude/rules/docs-style.md`.
 

--- a/docs/seo.py
+++ b/docs/seo.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Post-process the built mdBook site: inject canonical/OG/Twitter tags and
+write a sitemap.xml.
+
+mdBook 0.5.3's Handlebars context registers no string helpers, so a theme
+partial has no way to turn `introduction.md` (the only path it sees) into
+`introduction.html`. That rules out doing this at template-render time —
+instead we run after `mdbook build` and read the tags back out of the
+already-rendered HTML, where mdBook itself resolved everything correctly.
+Wired in via taskfiles/docs.taskfile.yml (`task docs:build`).
+"""
+import re
+from pathlib import Path
+from xml.sax.saxutils import escape
+
+# Canonical public origin (no trailing slash). Must match the Host used in
+# docs/src/robots.txt.
+SITE = "https://grimoire.rs"
+OG_IMAGE = f"{SITE}/og-card.png"  # produced by a separate worker at docs/src/og-card.png
+
+BOOK_DIR = Path(__file__).parent / "book"
+# print.html already carries its own noindex and must not get a competing
+# canonical; 404.html and toc.html are not indexable content pages either.
+SKIP = {"404.html", "print.html", "toc.html"}
+
+TITLE_RE = re.compile(r"<title>(.*?)</title>", re.DOTALL)
+DESC_RE = re.compile(r'<meta name="description" content="(.*?)">', re.DOTALL)
+MAIN_RE = re.compile(r"<main>(.*?)</main>", re.DOTALL)
+PARA_RE = re.compile(r"<p>(.*?)</p>", re.DOTALL)
+TAG_RE = re.compile(r"<[^>]+>")
+FALLBACK_TITLE = "Grimoire"
+FALLBACK_DESC = "An OCI-backed package manager for AI skills and rules"
+
+
+def page_url(rel_path):
+    if rel_path.name == "index.html":
+        return SITE + "/"
+    return "/".join([SITE, *rel_path.parts])
+
+
+def attr(text):
+    """Make already-escaped rendered HTML safe inside a double-quoted attribute.
+
+    The text comes straight out of mdBook's output, so `&`, `<` and `>` are
+    already entities — re-escaping them would double them up. Only the quote
+    that would close the attribute is left to handle.
+    """
+    return text.replace('"', "&quot;")
+
+
+def chapter_summary(html):
+    """First real paragraph of the chapter, for a per-page description.
+
+    book.toml carries one description for the whole book, so without this every
+    chapter would unfurl in Slack with identical text. Returns None when there
+    is nothing usable and the caller should fall back to the book description.
+    """
+    main = MAIN_RE.search(html)
+    if not main:
+        return None
+    for para in PARA_RE.finditer(main.group(1)):
+        text = " ".join(TAG_RE.sub("", para.group(1)).split())
+        # Short leading fragments are captions and admonition labels, not prose.
+        if len(text) > 80:
+            return text[:197].rsplit(" ", 1)[0] + "…" if len(text) > 200 else text
+    return None
+
+
+def process(path):
+    """Inject tags if missing; always return this page's canonical URL."""
+    rel = path.relative_to(BOOK_DIR)
+    url = page_url(rel)
+    html = path.read_text(encoding="utf-8")
+    if 'rel="canonical"' in html:
+        return url  # already tagged — idempotent, nothing to do
+
+    title_match = TITLE_RE.search(html)
+    title = title_match.group(1) if title_match else FALLBACK_TITLE
+    desc_match = DESC_RE.search(html)
+    description = desc_match.group(1) if desc_match else FALLBACK_DESC
+    if not title_match:
+        print(f"warning: {rel} has no <title>, using fallback")
+    if not desc_match:
+        print(f"warning: {rel} has no description meta, using fallback")
+
+    og_type = "website" if url == SITE + "/" else "article"
+    # The root is the product pitch, so the book description is the right blurb
+    # for it; chapters describe themselves.
+    if og_type == "article":
+        description = chapter_summary(html) or description
+    title, description = attr(title), attr(description)
+    tags = f"""<link rel="canonical" href="{url}">
+<meta property="og:type" content="{og_type}">
+<meta property="og:title" content="{title}">
+<meta property="og:description" content="{description}">
+<meta property="og:url" content="{url}">
+<meta property="og:image" content="{OG_IMAGE}">
+<meta property="og:site_name" content="Grimoire">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="{title}">
+<meta name="twitter:description" content="{description}">
+<meta name="twitter:image" content="{OG_IMAGE}">
+</head>"""
+    path.write_text(html.replace("</head>", tags, 1), encoding="utf-8")
+    return url
+
+
+def write_sitemap(urls):
+    urls = [SITE + "/"] + [u for u in urls if u != SITE + "/"]  # root first
+    body = "\n".join(f"  <url><loc>{escape(u)}</loc></url>" for u in urls)
+    xml = (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n'
+        f"{body}\n</urlset>\n"
+    )
+    (BOOK_DIR / "sitemap.xml").write_text(xml, encoding="utf-8")
+
+
+def main():
+    urls = [
+        process(path)
+        for path in sorted(BOOK_DIR.rglob("*.html"))
+        if path.name not in SKIP
+    ]
+    write_sitemap(urls)
+    print(f"seo.py: processed {len(urls)} pages, wrote sitemap.xml")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/src/og-card.png
+++ b/docs/src/og-card.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8f7e18aa28d721a6e3054e9e8f07c03f35a5583095df1806b1b5c4e1e7b2c450
+size 105570

--- a/docs/src/robots.txt
+++ b/docs/src/robots.txt
@@ -1,0 +1,5 @@
+User-agent: *
+Allow: /
+Disallow: /print.html
+
+Sitemap: https://grimoire.rs/sitemap.xml

--- a/taskfiles/docs.taskfile.yml
+++ b/taskfiles/docs.taskfile.yml
@@ -8,12 +8,16 @@ tasks:
     summary: |
       Regenerates the JSON Schemas (via :schema:generate) and then builds
       the mdBook site. The schema step runs first so the published site
-      always carries schemas that match the current parser. This is the
-      task CI runs to produce the GitHub Pages artifact.
+      always carries schemas that match the current parser. Afterwards,
+      docs/seo.py post-processes docs/book: it injects per-page canonical
+      and OG/Twitter meta tags (mdBook's Handlebars context can't compute
+      these itself) and writes sitemap.xml from the pages it just tagged.
+      This is the task CI runs to produce the GitHub Pages artifact.
     deps:
       - :schema:generate
     cmds:
       - mdbook build {{.ROOT_DIR}}/docs
+      - python3 {{.ROOT_DIR}}/docs/seo.py
 
   serve:
     desc: Generate schemas and serve the mdBook site locally (pass flags after --)


### PR DESCRIPTION
Closes the W5 site gaps ahead of 1.0. A grimoire.rs link posted anywhere today unfurls with no preview card at all, and the site ships no canonical URLs, no sitemap, and no `robots.txt`.

## What lands

- **Social preview card** — `assets/og-card.html` is the 1280×640 source; `docs/src/og-card.png` is the rendered asset the meta tags point at.
- **`docs/seo.py`** — post-processes `docs/book` after `mdbook build`, injecting per-page canonical, Open Graph, and Twitter meta and emitting `sitemap.xml`. Wired into `task docs:build`, so local builds and CI go through the same path.
- **`docs/src/robots.txt`** — points crawlers at the sitemap.
- **mdBook pinned to 0.5.3** in both the workflow and `docs/README.md`. `docs/theme/index.hbs` vendors that release's stock template byte for byte after the `{{else}}`; an unpinned bump would drift it silently.
- **`lfs: true` on the docs checkout** — `.gitattributes` tracks `*.png` in LFS, so `docs/src/og-card.png` is committed as a three-line pointer. Without this the Pages build published the pointer text as the card and `og:image` resolved to ASCII. Caught before the first deploy, not after.

## Verification

- `git cat-file -p HEAD:docs/src/og-card.png` → LFS pointer, `size 105570` — confirms the fix is load-bearing rather than defensive.
- The rendered asset is `PNG image data, 1280 x 640, 8-bit/color RGB` (`file docs/src/og-card.png`).
- No published URL moves: `seo.py` only adds `<head>` tags and writes new files beside the existing output.

## Not in this PR

- Uploading the card to each repo's **Settings → General → Social preview**. GitHub exposes no API for it; it stays a manual step.
- The landing-page client links and the compat-matrix marks — stacked on this branch, follow-up PR.