### PR TITLE
fix(announce): make a declined PR/MR say why

### DIFF
--- a/src/catalog/forge.rs
+++ b/src/catalog/forge.rs
@@ -540,12 +540,10 @@ async fn github_pull_request(
             .map(str::to_string)
             .ok_or_else(|| "pull request exists but could not be located".to_string());
     }
-    let body: serde_json::Value = response
-        .error_for_status()
-        .map_err(|e| e.to_string())?
-        .json()
-        .await
-        .map_err(|e| e.to_string())?;
+    if !response.status().is_success() {
+        return Err(status_error(response).await);
+    }
+    let body: serde_json::Value = response.json().await.map_err(|e| e.to_string())?;
     body.get("html_url")
         .and_then(serde_json::Value::as_str)
         .map(str::to_string)
@@ -623,12 +621,10 @@ async fn gitlab_merge_request(
             .map(str::to_string)
             .ok_or_else(|| "merge request exists but could not be located".to_string());
     }
-    let body: serde_json::Value = response
-        .error_for_status()
-        .map_err(|e| e.to_string())?
-        .json()
-        .await
-        .map_err(|e| e.to_string())?;
+    if !response.status().is_success() {
+        return Err(status_error(response).await);
+    }
+    let body: serde_json::Value = response.json().await.map_err(|e| e.to_string())?;
     body.get("web_url")
         .and_then(serde_json::Value::as_str)
         .map(str::to_string)
@@ -1358,6 +1354,31 @@ async fn get_json(http: &reqwest::Client, ctx: &ForgeContext, url: &str) -> Resu
     } else {
         Err(format!("HTTP status {status}"))
     }
+}
+
+/// The number of body characters kept in a [`status_error`] detail string —
+/// enough for a forge's own JSON error message, capped against a forge
+/// returning something large or hostile.
+const STATUS_ERROR_BODY_CAP: usize = 300;
+
+/// Build the detail string for a non-success `response`: the status plus
+/// (capped) body — the forge's own reason for a create-PR/MR failure lives
+/// in the body (`{"message": "...", ...}`), never in headers, which is why
+/// only the body is read here. Falls back to the status alone when the
+/// body is empty or unreadable, so the message is never worse than
+/// reporting the status by itself.
+async fn status_error(response: reqwest::Response) -> String {
+    let status = response.status();
+    let body = response.text().await.unwrap_or_default();
+    let body = body.trim();
+    if body.is_empty() {
+        return format!("HTTP status {status}");
+    }
+    let body = match body.char_indices().nth(STATUS_ERROR_BODY_CAP) {
+        Some((end, _)) => format!("{}… [truncated]", &body[..end]),
+        None => body.to_string(),
+    };
+    format!("HTTP status {status}: {body}")
 }
 
 #[cfg(test)]
@@ -2104,6 +2125,58 @@ mod tests {
             }
         });
         (host, handle)
+    }
+
+    /// Regression for the silent-decline bug's second half: raising the log
+    /// call to `warn` (see `create_change_request`) is pointless if
+    /// `{detail}` still carries only the bare status — the forge's actual
+    /// reason (e.g. GitHub's "Actions is not permitted to create or approve
+    /// pull requests") lives in the response body, so `status_error` must
+    /// read and fold it in.
+    #[tokio::test]
+    async fn status_error_includes_the_response_body_when_present() {
+        let body = r#"{"message":"GitHub Actions is not permitted to create or approve pull requests","documentation_url":"https://docs.github.com/rest/pulls/pulls#create-a-pull-request"}"#;
+        let (host, handle) = spawn_mock_forge(move |_first| {
+            format!(
+                "HTTP/1.1 403 Forbidden\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            )
+        })
+        .await;
+        let response = reqwest::Client::new()
+            .get(format!("http://{host}/repos/acme/index/pulls"))
+            .send()
+            .await
+            .unwrap();
+        let detail = status_error(response).await;
+        handle.abort();
+        assert!(detail.contains("403"), "{detail}");
+        assert!(
+            detail.contains("GitHub Actions is not permitted to create or approve pull requests"),
+            "{detail}"
+        );
+    }
+
+    /// The other half of the contract: an empty (or unreadable) body must
+    /// never make the message worse than today's status-only string.
+    #[tokio::test]
+    async fn status_error_falls_back_to_status_only_when_body_is_empty() {
+        let (host, handle) = spawn_mock_forge(|_first| {
+            "HTTP/1.1 403 Forbidden\r\ncontent-length: 0\r\nconnection: close\r\n\r\n".to_string()
+        })
+        .await;
+        let response = reqwest::Client::new()
+            .get(format!("http://{host}/repos/acme/index/pulls"))
+            .send()
+            .await
+            .unwrap();
+        let detail = status_error(response).await;
+        handle.abort();
+        assert_eq!(
+            detail, "HTTP status 403 Forbidden",
+            "empty body must fall back to status only"
+        );
     }
 
     /// A throwaway GitLab-shaped forge for the fork-identity gate (W6): the

--- a/src/catalog/forge.rs
+++ b/src/catalog/forge.rs
@@ -470,8 +470,8 @@ pub async fn create_change_request(
     match result {
         Ok(url) => Some(url),
         Err(detail) => {
-            tracing::info!(
-                "forge API did not open the change request ({detail}); the branch is pushed — open it manually"
+            tracing::warn!(
+                "forge API did not open the change request (reason: {detail}); the branch is pushed — open it manually (check the repo's or token's permission to create pull/merge requests)"
             );
             None
         }
@@ -2008,6 +2008,40 @@ mod tests {
         assert!(
             started.elapsed() < std::time::Duration::from_secs(5),
             "the short deadline must bound the wait"
+        );
+    }
+
+    /// Regression for the silent-decline bug: a forge API failure (here, a
+    /// transport-level failure — nothing listens on 127.0.0.1:1) must still
+    /// degrade `create_change_request` to `None` rather than propagating an
+    /// error, so the caller reports the pushed branch instead of failing the
+    /// whole announce. Proves the `Err(detail)` arm is reached and the
+    /// documented "best-effort, never worse than a plain push" contract
+    /// holds. Does **not** assert the log level of the emitted warning — no
+    /// tracing-capture pattern exists elsewhere in this crate to assert
+    /// against, so that part of the fix (`tracing::info!` → `tracing::warn!`)
+    /// is verified by code inspection only.
+    #[tokio::test]
+    async fn create_change_request_degrades_to_none_on_transport_failure() {
+        let ctx = ForgeContext {
+            kind: ForgeKind::GitHub,
+            api_url: Some("http://127.0.0.1:1".to_string()),
+            token: Some("ghp-x".to_string()),
+            ci_namespace: None,
+        };
+        let http = reqwest::Client::new();
+        let result = create_change_request(
+            &http,
+            &ctx,
+            "https://github.com/acme/index",
+            "announce/test",
+            "announce: test",
+            None,
+        )
+        .await;
+        assert_eq!(
+            result, None,
+            "an unreachable forge API must degrade to None, never fail the announce"
         );
     }
 


### PR DESCRIPTION
Found while running the index end-to-end trial against live GitHub repos.

## What happened

`grim publish --announce` from GitHub Actions published the bytes, pushed the announce branch, exited **0**, and reported:

```
announced: pushed branch 'announce/...' — open the merge request to publish the pointers
"announce": { "outcome": "branch-pushed", "url": null }
```

No PR was opened and nothing said why. The real reason — GitHub's repo setting *"Allow GitHub Actions to create and approve pull requests"*, off by default — was sitting in the API response body, unread.

Two things hid it:

1. `create_change_request` logged the failure at `tracing::info!`. `src/main.rs:278` sets the default filter to `EnvFilter::new("warn")`, so the one line carrying the reason was invisible unless you re-ran with `--log-level info` — which you have no reason to suspect.
2. Even at `warn`, `{detail}` came from `error_for_status()`, which keeps the status and discards the body. It would have read `HTTP status client error (403 Forbidden)` and nothing more.

## The change

- `tracing::info!` → `tracing::warn!` on that arm, message extended to point at the permission.
- New `status_error(response)` folds the response **body** into the detail for `github_pull_request` and `gitlab_merge_request`. Body only, never headers — a forge's reason lives in `{"message": ...}`, anything credential-shaped lives in headers. Capped at 300 chars on a char boundary; empty/unreadable body falls back to the status alone, so the message is never worse than today.

Result for the case that prompted this:

```
forge API did not open the change request (reason: HTTP status 403 Forbidden:
{"message":"GitHub Actions is not permitted to create or approve pull requests",...});
the branch is pushed — open it manually (check the repo's or token's permission
to create pull/merge requests)
```

## Not changed

`BranchPushed` stays a success and `create_change_request` keeps its `Option` return — a pushed branch really is a degraded success, and that shape is a frozen contract. The 422 "PR already exists" reuse branch returns **before** the new status guard, so that path is untouched.

## Tests

Three new, using the crate's existing raw-TCP `spawn_mock_forge` pattern (no new dependency):

- transport failure still degrades to `None` rather than failing the announce
- a 403 **with** a JSON body puts that body in the detail
- a 403 with an **empty** body yields exactly `HTTP status 403 Forbidden`

The log *level* itself is not asserted — no tracing-capture pattern exists in this crate and inventing one was out of scope. Stated in the test's doc comment rather than glossed.

`task verify`: 2319 unit + 864 acceptance tests, clippy and fmt clean.